### PR TITLE
OpenSL ES buffer callbacks on Android

### DIFF
--- a/Alc/backends/opensl.c
+++ b/Alc/backends/opensl.c
@@ -216,6 +216,7 @@ static void opensl_close_playback(ALCdevice *Device)
     data->engineObject = NULL;
     data->engine = NULL;
 
+    free(data->buffer);
     free(data);
     Device->ExtraData = NULL;
 }
@@ -309,6 +310,7 @@ static ALCboolean opensl_start_playback(ALCdevice *Device)
     }
     if(SL_RESULT_SUCCESS == result)
     {
+        free(data->buffer);
         data->frameSize = FrameSizeFromDevFmt(Device->FmtChans, Device->FmtType);
         data->bufferSize = Device->UpdateSize * data->frameSize;
         data->buffer = calloc(Device->NumUpdates, data->bufferSize);
@@ -379,10 +381,6 @@ static void opensl_stop_playback(ALCdevice *Device)
         result = VCALL0(bufferQueue,Clear)();
         PRINTERR(result, "bufferQueue->Clear");
     }
-
-    free(data->buffer);
-    data->buffer = NULL;
-    data->bufferSize = 0;
 }
 
 

--- a/Alc/backends/opensl.c
+++ b/Alc/backends/opensl.c
@@ -331,6 +331,7 @@ static ALCboolean opensl_start_playback(ALCdevice *Device)
         if(SL_RESULT_SUCCESS == result)
         {
             ALvoid *buf = (ALbyte*)data->buffer + i*data->bufferSize;
+            memset(buf, 0, data->bufferSize);
             result = VCALL(bufferQueue,Enqueue)(buf, data->bufferSize);
             PRINTERR(result, "bufferQueue->Enqueue");
         }


### PR DESCRIPTION
On some Android implementations of OpenSL ES the playback buffer callback can be called even after playback was stopped. This can lead to a crash when a callback happens after the buffer was freed. I could observe this behavior using the Android Emulator with API 17 and on a real device running API 19.

The Android NDK docs on OpenSL mention a similar behavior:
> A corollary is that it is unspecified whether buffer queue callbacks are called upon transition to SL_PLAYSTATE_STOPPED or by BufferQueue::Clear. We recommend that you do not rely on either behavior; be prepared to receive a callback in these cases, but also do not depend on receiving one.

To prevent this crash I changed the OpenSL ES back-end to free the buffer only after the buffer queue object was destroyed. I also moved the buffer allocation from the start to the reset function. With these changes I could not observer any further crashes.