### PR TITLE
ALc.c: ProbeDevices: Avoid crash when no capture device is available.

### DIFF
--- a/Alc/ALc.c
+++ b/Alc/ALc.c
@@ -1222,12 +1222,20 @@ static void alc_deinit(void)
 static void ProbeDevices(al_string *list, struct BackendInfo *backendinfo, enum DevProbe type)
 {
     DO_INITCONFIG();
-
     LockLists();
     al_string_clear(list);
-
     if(!backendinfo->getFactory)
-        backendinfo->Probe(type);
+    {
+        if(backendinfo->Probe)
+            backendinfo->Probe(type);
+        else
+        {
+            if(type == ALL_DEVICE_PROBE)
+                WARN("Playback Device not found\n");
+            else
+                WARN("Capture Device not found\n");
+        }
+    }
     else
     {
         ALCbackendFactory *factory = backendinfo->getFactory();


### PR DESCRIPTION
When no capture devices are available running `openal-info` crashes. This patch add an extra check.
This is generating the device that generate the crash:
https://github.com/kcat/openal-soft/blob/master/Alc/ALc.c#L1057-L1064