### PR TITLE
Fix placement of alignas - fixes Mac OS X build

### DIFF
--- a/Alc/mixer_sse2.c
+++ b/Alc/mixer_sse2.c
@@ -33,8 +33,8 @@ const ALfloat *Resample_lerp32_SSE2(const BsincState* UNUSED(state), const ALflo
     const __m128i increment4 = _mm_set1_epi32(increment*4);
     const __m128 fracOne4 = _mm_set1_ps(1.0f/FRACTIONONE);
     const __m128i fracMask4 = _mm_set1_epi32(FRACTIONMASK);
-    alignas(16) union { ALuint i[4]; float f[4]; } pos_;
-    alignas(16) union { ALuint i[4]; float f[4]; } frac_;
+    union { alignas(16) ALuint i[4]; float f[4]; } pos_;
+    union { alignas(16) ALuint i[4]; float f[4]; } frac_;
     __m128i frac4, pos4;
     ALuint pos;
     ALuint i;

--- a/Alc/mixer_sse3.c
+++ b/Alc/mixer_sse3.c
@@ -36,8 +36,8 @@ const ALfloat *Resample_fir4_32_SSE3(const BsincState* UNUSED(state), const ALfl
 {
     const __m128i increment4 = _mm_set1_epi32(increment*4);
     const __m128i fracMask4 = _mm_set1_epi32(FRACTIONMASK);
-    alignas(16) union { ALuint i[4]; float f[4]; } pos_;
-    alignas(16) union { ALuint i[4]; float f[4]; } frac_;
+    union { alignas(16) ALuint i[4]; float f[4]; } pos_;
+    union { alignas(16) ALuint i[4]; float f[4]; } frac_;
     __m128i frac4, pos4;
     ALuint pos;
     ALuint i;
@@ -100,8 +100,8 @@ const ALfloat *Resample_fir8_32_SSE3(const BsincState* UNUSED(state), const ALfl
 {
     const __m128i increment4 = _mm_set1_epi32(increment*4);
     const __m128i fracMask4 = _mm_set1_epi32(FRACTIONMASK);
-    alignas(16) union { ALuint i[4]; float f[4]; } pos_;
-    alignas(16) union { ALuint i[4]; float f[4]; } frac_;
+    union { alignas(16) ALuint i[4]; float f[4]; } pos_;
+    union { alignas(16) ALuint i[4]; float f[4]; } frac_;
     __m128i frac4, pos4;
     ALuint pos;
     ALuint i, j;

--- a/Alc/mixer_sse41.c
+++ b/Alc/mixer_sse41.c
@@ -34,8 +34,8 @@ const ALfloat *Resample_lerp32_SSE41(const BsincState* UNUSED(state), const ALfl
     const __m128i increment4 = _mm_set1_epi32(increment*4);
     const __m128 fracOne4 = _mm_set1_ps(1.0f/FRACTIONONE);
     const __m128i fracMask4 = _mm_set1_epi32(FRACTIONMASK);
-    alignas(16) union { ALuint i[4]; float f[4]; } pos_;
-    alignas(16) union { ALuint i[4]; float f[4]; } frac_;
+    union { alignas(16) ALuint i[4]; float f[4]; } pos_;
+    union { alignas(16) ALuint i[4]; float f[4]; } frac_;
     __m128i frac4, pos4;
     ALuint pos;
     ALuint i;
@@ -89,8 +89,8 @@ const ALfloat *Resample_fir4_32_SSE41(const BsincState* UNUSED(state), const ALf
 {
     const __m128i increment4 = _mm_set1_epi32(increment*4);
     const __m128i fracMask4 = _mm_set1_epi32(FRACTIONMASK);
-    alignas(16) union { ALuint i[4]; float f[4]; } pos_;
-    alignas(16) union { ALuint i[4]; float f[4]; } frac_;
+    union { alignas(16) ALuint i[4]; float f[4]; } pos_;
+    union { alignas(16) ALuint i[4]; float f[4]; } frac_;
     __m128i frac4, pos4;
     ALuint pos;
     ALuint i;
@@ -156,8 +156,8 @@ const ALfloat *Resample_fir8_32_SSE41(const BsincState* UNUSED(state), const ALf
 {
     const __m128i increment4 = _mm_set1_epi32(increment*4);
     const __m128i fracMask4 = _mm_set1_epi32(FRACTIONMASK);
-    alignas(16) union { ALuint i[4]; float f[4]; } pos_;
-    alignas(16) union { ALuint i[4]; float f[4]; } frac_;
+    union { alignas(16) ALuint i[4]; float f[4]; } pos_;
+    union { alignas(16) ALuint i[4]; float f[4]; } frac_;
     __m128i frac4, pos4;
     ALuint pos;
     ALuint i, j;


### PR DESCRIPTION
As previously discussed in IRC.  C, unlike C++, does not permit alignas() before the struct/union keyword, but it can be applied to the first member to equivalent effect.