### PR TITLE
alsoft-config: Raise source limit to 4096

### DIFF
--- a/utils/alsoft-config/mainwindow.cpp
+++ b/utils/alsoft-config/mainwindow.cpp
@@ -278,7 +278,7 @@ MainWindow::MainWindow(QWidget *parent) :
     mPeriodCountValidator = new QIntValidator(2, 16, this);
     ui->periodCountEdit->setValidator(mPeriodCountValidator);
 
-    mSourceCountValidator = new QIntValidator(0, 256, this);
+    mSourceCountValidator = new QIntValidator(0, 4096, this);
     ui->srcCountLineEdit->setValidator(mSourceCountValidator);
     mEffectSlotValidator = new QIntValidator(0, 16, this);
     ui->effectSlotLineEdit->setValidator(mEffectSlotValidator);


### PR DESCRIPTION
I considered putting INT_MAX or so here instead, but I think 4096 should be enough in practice, no?