### PR TITLE
build: added appveyor-ci script to verify windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+version: 1.17.2.{build}
+
+environment:
+    matrix:
+      - GEN: "Visual Studio 14 2015"
+        CFG: Release
+      - GEN: "Visual Studio 14 2015 Win64"
+        CFG: Release
+
+build_script:
+    - cd build
+    - cmake .. -G"%GEN%"
+    - cmake --build . --config %CFG% --clean-first
+


### PR DESCRIPTION
Added Appveyor-CI (https://www.appveyor.com/) support for Windows builds validation (32/64 bit MSVS 2015).
As for Travis-CI it is required to register your project on https://www.appveyor.com/