### PR TITLE
Enable and enforce dependencies on CI services.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,18 @@ install:
     fi
   - >
     if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BUILD_ANDROID}" == "true" ]]; then
-      curl -o ~/android-ndk.zip https://dl.google.com/android/repository/android-ndk-r14-linux-x86_64.zip
-      unzip -q ~/android-ndk.zip -d ~ \
-        'android-ndk-r14/build/cmake/*' \
-        'android-ndk-r14/platforms/android-9/arch-arm/*' \
-        'android-ndk-r14/source.properties' \
-        'android-ndk-r14/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/*' \
-        'android-ndk-r14/sysroot/*' \
-        'android-ndk-r14/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/*' \
-        'android-ndk-r14/toolchains/llvm/prebuilt/linux-x86_64/*'
-      sed -i -e 's/VERSION 3.6.0/VERSION 3.2/' ~/android-ndk-r14/build/cmake/android.toolchain.cmake
+      if [[ ! -d ~/android-ndk-r14 || -z "$(ls -A ~/android-ndk-r14)" ]]; then
+        curl -o ~/android-ndk.zip https://dl.google.com/android/repository/android-ndk-r14-linux-x86_64.zip
+        unzip -q ~/android-ndk.zip -d ~ \
+          'android-ndk-r14/build/cmake/*' \
+          'android-ndk-r14/platforms/android-9/arch-arm/*' \
+          'android-ndk-r14/source.properties' \
+          'android-ndk-r14/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/*' \
+          'android-ndk-r14/sysroot/*' \
+          'android-ndk-r14/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/*' \
+          'android-ndk-r14/toolchains/llvm/prebuilt/linux-x86_64/*'
+        sed -i -e 's/VERSION 3.6.0/VERSION 3.2/' ~/android-ndk-r14/build/cmake/android.toolchain.cmake
+      fi
     fi
 script:
   - >

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
-os:
-  - linux
-  - osx
-dist: trusty
-sudo: required
 language: c
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+    - os: osx
+sudo: required
 install:
   - >
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,25 @@ install:
 script:
   - >
     if [[ "${TRAVIS_OS_NAME}" == "linux" && -z "${BUILD_ANDROID}" ]]; then
-      cmake .
+      cmake \
+        -DALSOFT_REQUIRE_ALSA=ON \
+        -DALSOFT_REQUIRE_OSS=ON \
+        -DALSOFT_REQUIRE_PORTAUDIO=ON \
+        -DALSOFT_REQUIRE_PULSEAUDIO=ON \
+        -DALSOFT_REQUIRE_JACK=ON \
+        .
     fi
   - >
     if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BUILD_ANDROID}" == "true" ]]; then
       cmake \
         -DCMAKE_TOOLCHAIN_FILE=~/android-ndk-r14/build/cmake/android.toolchain.cmake \
+        -DALSOFT_REQUIRE_OPENSL=ON \
         .
     fi
   - >
     if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      cmake .
+      cmake \
+        -DALSOFT_REQUIRE_COREAUDIO=ON \
+        .
     fi
   - make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,14 @@ install:
   - >
     if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BUILD_ANDROID}" == "true" ]]; then
       curl -o ~/android-ndk.zip https://dl.google.com/android/repository/android-ndk-r14-linux-x86_64.zip
-      unzip -q ~/android-ndk.zip -d ~
+      unzip -q ~/android-ndk.zip -d ~ \
+        'android-ndk-r14/build/cmake/*' \
+        'android-ndk-r14/platforms/android-9/arch-arm/*' \
+        'android-ndk-r14/source.properties' \
+        'android-ndk-r14/sources/cxx-stl/gnu-libstdc++/4.9/libs/armeabi-v7a/*' \
+        'android-ndk-r14/sysroot/*' \
+        'android-ndk-r14/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/*' \
+        'android-ndk-r14/toolchains/llvm/prebuilt/linux-x86_64/*'
       sed -i -e 's/VERSION 3.6.0/VERSION 3.2/' ~/android-ndk-r14/build/cmake/android.toolchain.cmake
     fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,15 @@ matrix:
   include:
     - os: linux
       dist: trusty
+    - os: linux
+      dist: trusty
+      env:
+        - BUILD_ANDROID=true
     - os: osx
 sudo: required
 install:
   - >
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+    if [[ "${TRAVIS_OS_NAME}" == "linux" && -z "${BUILD_ANDROID}" ]]; then
       # Install pulseaudio, portaudio, ALSA, JACK dependencies for
       # corresponding backends.
       # Install Qt5 dependency for alsoft-config.
@@ -18,4 +22,25 @@ install:
         libjack-dev \
         qtbase5-dev
     fi
-script: cmake . && make -j2
+  - >
+    if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BUILD_ANDROID}" == "true" ]]; then
+      curl -o ~/android-ndk.zip https://dl.google.com/android/repository/android-ndk-r14-linux-x86_64.zip
+      unzip -q ~/android-ndk.zip -d ~
+      sed -i -e 's/VERSION 3.6.0/VERSION 3.2/' ~/android-ndk-r14/build/cmake/android.toolchain.cmake
+    fi
+script:
+  - >
+    if [[ "${TRAVIS_OS_NAME}" == "linux" && -z "${BUILD_ANDROID}" ]]; then
+      cmake .
+    fi
+  - >
+    if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BUILD_ANDROID}" == "true" ]]; then
+      cmake \
+        -DCMAKE_TOOLCHAIN_FILE=~/android-ndk-r14/build/cmake/android.toolchain.cmake \
+        .
+    fi
+  - >
+    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+      cmake .
+    fi
+  - make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
         - BUILD_ANDROID=true
     - os: osx
 sudo: required
+cache:
+  directories:
+    - $HOME/android-ndk-r14
 install:
   - >
     if [[ "${TRAVIS_OS_NAME}" == "linux" && -z "${BUILD_ANDROID}" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,19 @@ os:
   - linux
   - osx
 dist: trusty
+sudo: required
 language: c
+install:
+  - >
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      # Install pulseaudio, portaudio, ALSA, JACK dependencies for
+      # corresponding backends.
+      # Install Qt5 dependency for alsoft-config.
+      sudo apt-get install -qq \
+        libpulse-dev \
+        portaudio19-dev \
+        libasound2-dev \
+        libjack-dev \
+        qtbase5-dev
+    fi
 script: cmake . && make -j2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,11 @@ environment:
       - GEN: "Visual Studio 14 2015 Win64"
         CFG: Release
 
+install:
+    # Remove the VS Xamarin targets to reduce AppVeyor specific noise in build
+    # logs.  See also http://help.appveyor.com/discussions/problems/4569
+    - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
+
 build_script:
     - cd build
     - cmake .. -G"%GEN%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,6 @@ install:
 
 build_script:
     - cd build
-    - cmake .. -G"%GEN%"
+    - cmake -G"%GEN%" -DALSOFT_REQUIRE_WINMM=ON -DALSOFT_REQUIRE_DSOUND=ON -DALSOFT_REQUIRE_MMDEVAPI=ON ..
     - cmake --build . --config %CFG% --clean-first
 


### PR DESCRIPTION
This PR is a work in progress

This PR (should) contain commits to allow that more parts of the project like backends or example programs are build and enforced to build to check for regressions in the build system.  Due to the nature of the CI services in question I can only test changes as external contributor by pushing to to this PR.  I will notify you when I consider the changes good enough for a review.