### PR TITLE
Suggestion: Clarify float format symbols

### DIFF
--- a/include/AL/alext.h
+++ b/include/AL/alext.h
@@ -97,6 +97,17 @@ extern "C" {
 
 #ifndef AL_EXT_MCFORMATS
 #define AL_EXT_MCFORMATS 1
+/*
+ * QUAD -> 4.0 quad (FL, FR, BL, BR)
+ * REAR -> rear stereo (BL, BR)
+ * 51CHN -> 5.1 (FL, FR, FC, LFE, SL, SR)
+ * 61CHN -> 6.1 (FL, FR, FC, LFE, BC, SL, SR)
+ * 71CHN -> 7.1 (FL, FR, FC, LFE, BL, BR, SL, SR)
+ *
+ * 8 -> unsigned 8-bit integer
+ * 16 -> signed 16-bit integer
+ * 32 -> IEEE 32-bit float
+ */
 #define AL_FORMAT_QUAD8                          0x1204
 #define AL_FORMAT_QUAD16                         0x1205
 #define AL_FORMAT_QUAD32                         0x1206


### PR DESCRIPTION
I won't be offended if you close this with "get a clue" ;)

I find it confusing that the integer formats consistently are untyped (AL_FORMAT_QUAD8, AL_MONO8_SOFT, AL_FORMAT_BFORMAT2D_8) and float formats are consistently typed (AL_MONO32F_SOFT, AL_FORMAT_BFORMAT2D_FLOAT32) except in the case of the multichannel extension, where the float format is untyped (AL_FORMAT_QUAD32). This led me to reject what was probably a perfectly fine patch to Wine, see https://bugs.winehq.org/show_bug.cgi?id=42414

There's some evidence that I'm not the only clueless one:

http://openal.org/pipermail/openal/2014-December/000286.html

https://developer.xamarin.com/api/type/OpenTK.Audio.OpenAL.ALFormat/

This PR has two commits, either of which alone would solve the problem, so both may be overkill. The first simply adds a comment to the header explicitly explaining each format. The second adds "32F" style aliases to the existing "32" symbols. You have a better picture of the pros/cons of adding new symbols than I do.