### PR TITLE
Restore the JACK error message handler in a JACK1 compatible manner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1033,6 +1033,14 @@ IF(JACK_FOUND)
         SET(BACKENDS  "${BACKENDS} JACK${IS_LINKED},")
         SET(ALC_OBJS  ${ALC_OBJS} Alc/backends/jack.c)
         ADD_BACKEND_LIBS(${JACK_LIBRARIES})
+        SET(OLD_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES})
+        SET(CMAKE_REQUIRED_LIBRARIES ${OLD_REQUIRED_LIBRARIES} ${JACK_LIBRARIES})
+        CHECK_C_SOURCE_COMPILES("extern void default_jack_error_callback(const char *);
+	                         int main() {
+                                     default_jack_error_callback(\"\");
+                                     return 0;
+                                }" HAVE_DEFAULT_JACK_ERROR_CALLBACK)
+        SET(CMAKE_REQUIRED_LIBRARIES ${OLD_REQUIRED_LIBRARIES})
     ENDIF()
 ENDIF()
 IF(ALSOFT_REQUIRE_JACK AND NOT HAVE_JACK)


### PR DESCRIPTION
JACK1 does not allow `NULL` to be passed to `jack_set_*_function`, while JACK2
restores the default callback.  This change explicitly resets the error function to `default_jack_error_callback`, as provided by the library, and is compatible with
both versions.

Fixes #138 