### PR TITLE
Fix build on Gentoo FreeBSD with freebsd-lib 9.1

### DIFF
--- a/Alc/helpers.c
+++ b/Alc/helpers.c
@@ -41,6 +41,7 @@
 #endif
 
 #ifdef __FreeBSD__
+#include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
I encountered this build error when trying to compile OpenAL Soft for Gentoo FreeBSD:

    In file included from /usr/x86_64-gentoo-freebsd9.1/tmp/portage/media-libs/openal-1.18.1/work/openal-soft-1.18.1/Alc/helpers.c:44:0:
    /usr/x86_64-gentoo-freebsd9.1/usr/include/sys/sysctl.h:799:25: error: unknown type name ‘u_int’
     int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
                             ^
 
Gentoo FreeBSD is barely maintained and 9.1 is an old version of freebsd-lib but according to the [sysctl manpage](https://www.freebsd.org/cgi/man.cgi?sysctl(3)) including both headers is the correct thing to do.