### PR TITLE
Do not probe a device which backend not fully implemented.

### DIFF
--- a/Alc/ALc.c
+++ b/Alc/ALc.c
@@ -1297,6 +1297,8 @@ static void ProbeDevices(al_string *list, struct BackendInfo *backendinfo, enum 
     LockLists();
     alstr_clear(list);
 
+    if (!backendinfo->getFactory)
+        return;
     factory = backendinfo->getFactory();
     V(factory,probe)(type);
 


### PR DESCRIPTION
Spotted with backend without capture device handling.