### PR TITLE
Add option to disable "build_version" cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ OPTION(ALSOFT_CONFIG "Install alsoft.conf sample configuration file" ON)
 OPTION(ALSOFT_HRTF_DEFS "Install HRTF definition files" ON)
 OPTION(ALSOFT_AMBDEC_PRESETS "Install AmbDec preset files" ON)
 OPTION(ALSOFT_INSTALL "Install headers and libraries" ON)
+OPTION(ALSOFT_UPDATE_BUILD_VERSION "Update git build version info" ON)
 
 if(DEFINED SHARE_INSTALL_DIR)
     message(WARNING "SHARE_INSTALL_DIR is deprecated.  Use the variables provided by the GNUInstallDirs module instead")
@@ -1136,7 +1137,7 @@ SET(BACKENDS  "${BACKENDS} Null")
 
 
 FIND_PACKAGE(Git)
-IF(GIT_FOUND AND EXISTS "${OpenAL_SOURCE_DIR}/.git")
+IF(ALSOFT_UPDATE_BUILD_VERSION AND GIT_FOUND AND EXISTS "${OpenAL_SOURCE_DIR}/.git")
     # Get the current working branch and its latest abbreviated commit hash
     ADD_CUSTOM_TARGET(build_version
         ${CMAKE_COMMAND} -D GIT_EXECUTABLE=${GIT_EXECUTABLE}


### PR DESCRIPTION
When using openal-soft as a git submodule, the "build_version" target currently gets generated. This causes any cmake targets that link against openal-soft to request a build every time they are launched in Visual Studio. I've added a new cmake option to allow disabling the creation of the "build_version" target to get around this issue.