### PR TITLE
freebsd fix: typo

### DIFF
--- a/Alc/helpers.c
+++ b/Alc/helpers.c
@@ -735,7 +735,7 @@ void GetProcBinary(al_string *path, al_string *fname)
     size_t pathlen;
 
 #ifdef __FreeBSD__
-    int mib[4] = { CTL_KERN, KERN_PROCARGS, getpid() };
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, getpid() };
     if(sysctl(mib, 3, NULL, &pathlen, NULL, 0) == -1)
         WARN("Failed to sysctl kern.procargs.%d: %s\n", mib[2], strerror(errno));
     else


### PR DESCRIPTION
Alc/helpers.c:738:30: error: use of undeclared identifier 'KERN_PROCARGS'
    int mib[4] = { CTL_KERN, KERN_PROCARGS, getpid() };

/usr/include/sys/sysctl.h:
`#define	KERN_PROC_ARGS		7	/* get/set arguments/proctitle */`
there's no KERN_PROCARGS