### PR TITLE
fix building on freebsd (clang), maybe osx too

### DIFF
--- a/examples/alffplay.cpp
+++ b/examples/alffplay.cpp
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <deque>
 #include <array>
+#include <cmath>
 
 extern "C" {
 #include "libavcodec/avcodec.h"


### PR DESCRIPTION
fixes error: 'pow' is not a member of 'std'