### PR TITLE
Examples: Fix MSVC link error

### DIFF
--- a/examples/alrecord.c
+++ b/examples/alrecord.c
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
                 return 1;
             }
 
-            recorder.mRecTime = strtof(argv[1], &end);
+            recorder.mRecTime = (float)strtod(argv[1], &end);
             if(!(recorder.mRecTime >= 1.0f && recorder.mRecTime <= 10.0f) || (end && *end != '\0'))
             {
                 fprintf(stderr, "Invalid record time: %s\n", argv[1]);


### PR DESCRIPTION
### PROPOSE
MSVC prior to 2013  does not include `strtof ` in `<stdlib.h>`.  This commit fix this issue for ms compilers prior to VS2013.

See strtof in MSDN: [https://msdn.microsoft.com/en-us/library/dn320175(v=vs.140).aspx](https://msdn.microsoft.com/en-us/library/dn320175(v=vs.140).aspx)

Review it and merge, please.
Thanks