### PR TITLE
Added missing string include to alffplay

### DIFF
--- a/examples/alffplay.cpp
+++ b/examples/alffplay.cpp
@@ -19,6 +19,7 @@
 #include <deque>
 #include <array>
 #include <cmath>
+#include <string>
 
 extern "C" {
 #include "libavcodec/avcodec.h"


### PR DESCRIPTION
I had compile errors with visual studio 2017 when building the alffplay binary:
```
3>alffplay.cpp
3>C:\projects\leviathan\ThirdParty\openal-soft\examples\alffplay.cpp(255): warning C4267: 'argument': conversion from 'size_t' to 'ALsizei', possible loss of data
3>C:\projects\leviathan\ThirdParty\openal-soft\examples\alffplay.cpp(715): error C2679: binary '<<': no operator found which takes a right-hand operand of type 'std::string' (or there is no acceptable conversion)
3>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.12.25827\include\ostream(488): note: could be 'std::basic_ostream<char,std::char_traits<char>> &std::basic_ostream<char,std::char_traits<char>>::operator <<(std::basic_streambuf<char,std::char_traits<char>> *)'
...
```
I was able to fix this and get everything to compile by adding this string include.