### PR TITLE
EFX: Modulator fixes

### DIFF
--- a/Alc/effects/modulator.c
+++ b/Alc/effects/modulator.c
@@ -63,17 +63,17 @@ DEFINE_ALEFFECTSTATE_VTABLE(ALmodulatorState);
 
 static inline ALfloat Sin(ALsizei index)
 {
-    return sinf(index*(F_TAU/WAVEFORM_FRACONE) - F_PI)*0.5f + 0.5f;
+    return sinf(index * (F_TAU / WAVEFORM_FRACONE));
 }
 
 static inline ALfloat Saw(ALsizei index)
 {
-    return (ALfloat)index / WAVEFORM_FRACONE;
+    return index*(2.0f/WAVEFORM_FRACONE) - 1.0f;
 }
 
 static inline ALfloat Square(ALsizei index)
 {
-    return (ALfloat)((index >> (WAVEFORM_FRACBITS - 1)) & 1);
+    return ((index>>(WAVEFORM_FRACBITS-1))&1)*2.0f - 1.0f;
 }
 
 #define DECL_TEMPLATE(func)                                                   \


### PR DESCRIPTION
This pull request fixes the carrier signal type from unipolar to bipolar because in a ring modulator the carrier signal is bipolar (DC=0). Originally, the implementation was correct, but it was changed in https://github.com/kcat/openal-soft/commit/a7ad6080f0d3fc783fd5e1811b961ab9efe79cde.

For example, references:

- [Refining Sound: A Practical Guide to Synthesis and Synthesizers](https://books.google.es/books?id=RlwWDAAAQBAJ&pg=PT213&dq=ring+modulator&hl=es&sa=X&redir_esc=y#v=onepage&q=ring%20modulator&f=false)
- [Introduction to Computer Music](https://books.google.es/books?id=mCpqmESEOEcC&pg=PA124&lpg=PA124&dq=ring+modulator+unipolar&source=bl&ots=uAjwND7dDh&sig=t5xKTVt5CQKMdAEnEDeVWADPmmQ&hl=es&sa=X&ved=0ahUKEwi6xI-8hbDbAhWFRhQKHcpCDfUQ6AEIPzAC#v=onepage&q=ring%20modulator%20unipolar&f=false)
- [DAFX - Digital Audio Effects](https://books.google.es/books?id=h90HIV0uwVsC&pg=PA76&dq=ring+modulator&hl=es&sa=X&ved=0ahUKEwix6PKwgbDbAhXJVsAKHXNgCk8Q6AEIMDAB#v=onepage&q=ring%20modulator&f=false)
- [CSound manual](http://write.flossmanuals.net/csound/c-amplitude-and-ring-modulation/)

Review and merge it, please
Thanks