### PR TITLE
Stop capture devices while closing

### DIFF
--- a/Alc/ALc.c
+++ b/Alc/ALc.c
@@ -4401,6 +4401,12 @@ ALC_API ALCboolean ALC_APIENTRY alcCaptureCloseDevice(ALCdevice *device)
     }
     UnlockLists();
 
+    almtx_lock(&device->BackendLock);
+    if((device->Flags&DEVICE_RUNNING))
+        V0(device->Backend,stop)();
+    device->Flags &= ~DEVICE_RUNNING;
+    almtx_unlock(&device->BackendLock);
+
     ALCdevice_DecRef(device);
 
     return ALC_TRUE;


### PR DESCRIPTION
In 'alcCaptureCloseDevice`, check if the capture device is running and stop it if necessary.

This fixes the case where the device data is deallocated while a background thread is still running (Issue #199)