### PR TITLE
Correctly check byte order for newer Android compiler, fix #203

### DIFF
--- a/OpenAL32/Include/alMain.h
+++ b/OpenAL32/Include/alMain.h
@@ -184,8 +184,8 @@ inline int fallback_ctz64(ALuint64 value)
 #define CTZ64 fallback_ctz64
 #endif
 
-#if defined(__BYTE_ORDER__) && defined(__LITTLE_ENDIAN__)
-#define IS_LITTLE_ENDIAN (__BYTE_ORDER__ == __LITTLE_ENDIAN__)
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+#define IS_LITTLE_ENDIAN (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #else
 static const union {
     ALuint u;


### PR DESCRIPTION
Shortly after I've opened the issue, I found the cause for the wrong return value of `IS_LITTLE_ENDIAN`: `__BYTE_ORDER__` is set to `__ORDER_LITTLE_ENDIAN__` instead of just `__LITTLE_ENDIAN__` (Android NDK r17 btw).