### PR TITLE
Prefer sndio backend over OSS when both are enabled

### DIFF
--- a/Alc/ALc.c
+++ b/Alc/ALc.c
@@ -75,14 +75,14 @@ static struct BackendInfo BackendList[] = {
 #ifdef HAVE_COREAUDIO
     { "core", ALCcoreAudioBackendFactory_getFactory },
 #endif
-#ifdef HAVE_OSS
-    { "oss", ALCossBackendFactory_getFactory },
-#endif
 #ifdef HAVE_SOLARIS
     { "solaris", ALCsolarisBackendFactory_getFactory },
 #endif
 #ifdef HAVE_SNDIO
     { "sndio", ALCsndioBackendFactory_getFactory },
+#endif
+#ifdef HAVE_OSS
+    { "oss", ALCossBackendFactory_getFactory },
 #endif
 #ifdef HAVE_QSA
     { "qsa", ALCqsaBackendFactory_getFactory },


### PR DESCRIPTION
The common fallback order for libraries and applications which have an sndio and OSS backend is to first try sndio and only if that doesn't work try OSS.

I currently apply this patch to the FreeBSD port as the current behavior (OSS before sndio) represents a POLA violation vs the rest of the Ports Collection. This is likely a FreeBSD-only issue but it's similar to how it works with PulseAudio and ALSA on Linux.