### PR TITLE
B-format support in HRTF example

### DIFF
--- a/examples/alhrtf.c
+++ b/examples/alhrtf.c
@@ -301,6 +301,10 @@ int main(int argc, char **argv)
         /* This only rotates mono sounds. */
         alSource3f(source, AL_POSITION, (ALfloat)sin(angle), 0.0f, -(ALfloat)cos(angle));
 
+        /* This rotates b-format sources. */
+        ALfloat sourceOri[] = { (ALfloat)sin(-angle), 0.0f, -(ALfloat)cos(-angle), 0.0, 1.0, 0.0 };
+        alSourcefv(source, AL_ORIENTATION, sourceOri);
+
         if(has_angle_ext)
         {
             /* This rotates stereo sounds with the AL_EXT_STEREO_ANGLES

--- a/examples/alhrtf.c
+++ b/examples/alhrtf.c
@@ -89,6 +89,36 @@ static ALuint LoadSound(const char *filename)
             return 0;
         }
     }
+    else if(sample->actual.channels == 3)
+    {
+        if(sample->actual.format == AUDIO_U8)
+            format = AL_FORMAT_BFORMAT2D_8;
+        else if(sample->actual.format == AUDIO_S16SYS)
+            format = AL_FORMAT_BFORMAT2D_16;
+        else if(sample->actual.format == AUDIO_F32SYS)
+          format = AL_FORMAT_BFORMAT2D_FLOAT32;
+        else
+        {
+            fprintf(stderr, "Unsupported 3 channel sample format: 0x%04x\n", sample->actual.format);
+            Sound_FreeSample(sample);
+            return 0;
+        }
+    }
+    else if(sample->actual.channels == 4)
+    {
+        if(sample->actual.format == AUDIO_U8)
+            format = AL_FORMAT_BFORMAT3D_8;
+        else if(sample->actual.format == AUDIO_S16SYS)
+            format = AL_FORMAT_BFORMAT3D_16;
+        else if(sample->actual.format == AUDIO_F32SYS)
+          format = AL_FORMAT_BFORMAT3D_FLOAT32;
+        else
+        {
+            fprintf(stderr, "Unsupported 4 channel sample format: 0x%04x\n", sample->actual.format);
+            Sound_FreeSample(sample);
+            return 0;
+        }
+    }
     else
     {
         fprintf(stderr, "Unsupported channel count: %d\n", sample->actual.channels);


### PR DESCRIPTION
This pull request adds B-format support to the example file alhrtf.c by 1) adding three and four channel audio loading support, and 2) using source orientation to demonstrate rotating B-format playback.

It is unclear, however, how to control the channel order and normalization standard settings. I cannot find anything in the documentation, but my FOA FuMa file seems to play okay.