### PR TITLE
Fix compilation with older Android NDK / API level

### DIFF
--- a/common/math_defs.h
+++ b/common/math_defs.h
@@ -27,6 +27,9 @@ static const union msvc_inf_hack {
 #endif
 
 #ifndef HAVE_LOG2F
+#ifdef log2f
+#undef log2f
+#endif
 static inline float log2f(float f)
 {
     return logf(f) / logf(2.0f);


### PR DESCRIPTION
Using an older Android target API level and NDK, `log2f` appears to not work properly. Using `HAVE_LOG2F` results in a linker error that the symbol for "log2f" cannot be found, but compiling without results in a conflict due to `static inline` vs. `inline` in the standard library.

This is one solution for resolving compilation for older Android NDK environments