### PR TITLE
Use GCD semaphore on macOS

### DIFF
--- a/common/threads.h
+++ b/common/threads.h
@@ -130,13 +130,21 @@ inline int altss_set(altss_t tss_id, void *val)
 #include <stdint.h>
 #include <errno.h>
 #include <pthread.h>
+#ifdef __APPLE__
+#include <dispatch/dispatch.h>
+#else /* !__APPLE__ */
 #include <semaphore.h>
+#endif /* __APPLE__ */
 
 
 typedef pthread_t althrd_t;
 typedef pthread_mutex_t almtx_t;
 typedef pthread_cond_t alcnd_t;
+#ifdef __APPLE__
+typedef dispatch_semaphore_t alsem_t;
+#else /* !__APPLE__ */
 typedef sem_t alsem_t;
+#endif /* __APPLE__ */
 typedef pthread_key_t altss_t;
 typedef pthread_once_t alonce_flag;
 


### PR DESCRIPTION
After updating OpenAL Soft to 1.19.1 I noticed an excessive CPU usage in GZDoom running on macOS. One core is fully occupied by OpenAL event thread.  
Bisecting changes revealed that the issue was introduced in cb8545346d227ba85a4a98c3897b5cdb1ea86d26.

The problem is POSIX unnamed semaphore doesn't work on macOS. [Here](https://stackoverflow.com/questions/27736618/why-are-sem-init-sem-getvalue-sem-destroy-deprecated-on-mac-os-x-and-w) is a related Stack Overflow discussion. Using Grand Central Dispatch semaphore instead of `sem_...` functions solved the issue for me.