### PR TITLE
alcResetDeviceSOFT: try reactivating the device if it has been disconnected.

### DIFF
--- a/Alc/ALu.c
+++ b/Alc/ALu.c
@@ -1877,7 +1877,7 @@ void aluHandleDisconnect(ALCdevice *device, const char *msg, ...)
     va_list args;
     int msglen;
 
-    if(!ATOMIC_EXCHANGE(&device->Connected, AL_FALSE, almemory_order_acq_rel))
+    if(ATOMIC_EXCHANGE(&device->Connected, DeviceConnect_Disconnected, almemory_order_acq_rel) != DeviceConnect_Connected)
         return;
 
     evt.u.user.type = AL_EVENT_TYPE_DISCONNECTED_SOFT;

--- a/Alc/backends/alsa.c
+++ b/Alc/backends/alsa.c
@@ -1216,7 +1216,7 @@ static ALCenum ALCcaptureAlsa_captureSamples(ALCcaptureAlsa *self, ALCvoid *buff
     }
 
     self->last_avail -= samples;
-    while(ATOMIC_LOAD(&device->Connected, almemory_order_acquire) && samples > 0)
+    while(ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected && samples > 0)
     {
         snd_pcm_sframes_t amt = 0;
 
@@ -1284,7 +1284,7 @@ static ALCuint ALCcaptureAlsa_availableSamples(ALCcaptureAlsa *self)
     ALCdevice *device = STATIC_CAST(ALCbackend, self)->mDevice;
     snd_pcm_sframes_t avail = 0;
 
-    if(ATOMIC_LOAD(&device->Connected, almemory_order_acquire) && self->doCapture)
+    if(ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected && self->doCapture)
         avail = snd_pcm_avail_update(self->pcmHandle);
     if(avail < 0)
     {

--- a/Alc/backends/dsound.c
+++ b/Alc/backends/dsound.c
@@ -278,7 +278,7 @@ FORCE_ALIGN static int ALCdsoundPlayback_mixerProc(void *ptr)
 
     IDirectSoundBuffer_GetCurrentPosition(self->Buffer, &LastCursor, NULL);
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         // Get current play cursor
         IDirectSoundBuffer_GetCurrentPosition(self->Buffer, &PlayCursor, NULL);
@@ -930,7 +930,7 @@ static ALCuint ALCdsoundCapture_availableSamples(ALCdsoundCapture *self)
     DWORD FrameSize;
     HRESULT hr;
 
-    if(!ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+    if(ATOMIC_LOAD(&device->Connected, almemory_order_acquire) == DeviceConnect_Disconnected)
         goto done;
 
     FrameSize = FrameSizeFromDevFmt(device->FmtChans, device->FmtType, device->AmbiOrder);

--- a/Alc/backends/jack.c
+++ b/Alc/backends/jack.c
@@ -313,7 +313,7 @@ static int ALCjackPlayback_mixerProc(void *arg)
 
     ALCjackPlayback_lock(self);
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         ALuint todo, len1, len2;
 

--- a/Alc/backends/null.c
+++ b/Alc/backends/null.c
@@ -89,7 +89,7 @@ static int ALCnullBackend_mixerProc(void *ptr)
         return 1;
     }
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         if(altimespec_get(&now, AL_TIME_UTC) != AL_TIME_UTC)
         {

--- a/Alc/backends/opensl.c
+++ b/Alc/backends/opensl.c
@@ -261,7 +261,7 @@ static int ALCopenslPlayback_mixerProc(void *arg)
 
     while(SL_RESULT_SUCCESS == result &&
           !ATOMIC_LOAD(&self->mKillNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         size_t todo;
 

--- a/Alc/backends/oss.c
+++ b/Alc/backends/oss.c
@@ -285,7 +285,7 @@ static int ALCplaybackOSS_mixerProc(void *ptr)
 
     ALCplaybackOSS_lock(self);
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         FD_ZERO(&wfds);
         FD_SET(self->fd, &wfds);

--- a/Alc/backends/pulseaudio.c
+++ b/Alc/backends/pulseaudio.c
@@ -831,7 +831,7 @@ static int ALCpulsePlayback_mixerProc(void *ptr)
     frame_size = pa_frame_size(&self->spec);
 
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         void *buf;
         int ret;
@@ -1695,7 +1695,7 @@ static ALCuint ALCpulseCapture_availableSamples(ALCpulseCapture *self)
     ALCdevice *device = STATIC_CAST(ALCbackend,self)->mDevice;
     size_t readable = self->cap_remain;
 
-    if(ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+    if(ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         ssize_t got;
         pa_threaded_mainloop_lock(self->loop);

--- a/Alc/backends/sndio.c
+++ b/Alc/backends/sndio.c
@@ -103,7 +103,7 @@ static int SndioPlayback_mixerProc(void *ptr)
     frameSize = FrameSizeFromDevFmt(device->FmtChans, device->FmtType, device->AmbiOrder);
 
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         ALsizei len = self->data_size;
         ALubyte *WritePtr = self->mix_data;
@@ -344,7 +344,7 @@ static int SndioCapture_recordProc(void* ptr)
     frameSize = FrameSizeFromDevFmt(device->FmtChans, device->FmtType, device->AmbiOrder);
 
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         ll_ringbuffer_data_t data[2];
         size_t total, todo;

--- a/Alc/backends/solaris.c
+++ b/Alc/backends/solaris.c
@@ -121,7 +121,7 @@ static int ALCsolarisBackend_mixerProc(void *ptr)
 
     ALCsolarisBackend_lock(self);
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         FD_ZERO(&wfds);
         FD_SET(self->fd, &wfds);

--- a/Alc/backends/wave.c
+++ b/Alc/backends/wave.c
@@ -144,7 +144,7 @@ static int ALCwaveBackend_mixerProc(void *ptr)
         return 1;
     }
     while(!ATOMIC_LOAD(&self->killNow, almemory_order_acquire) &&
-          ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+          ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Disconnected)
     {
         if(altimespec_get(&now, AL_TIME_UTC) != AL_TIME_UTC)
         {

--- a/OpenAL32/Include/alMain.h
+++ b/OpenAL32/Include/alMain.h
@@ -490,6 +490,12 @@ enum RenderMode {
     HrtfRender
 };
 
+enum DeviceConnect {
+    DeviceConnect_Disconnected,
+    DeviceConnect_Connecting,
+    DeviceConnect_Connected
+};
+
 
 /* The maximum number of Ambisonics coefficients. For a given order (o), the
  * size needed will be (o+1)**2, thus zero-order has 1, first-order has 4,
@@ -606,7 +612,7 @@ typedef void (*POSTPROCESS)(ALCdevice *device, ALsizei SamplesToDo);
 struct ALCdevice_struct {
     RefCount ref;
 
-    ATOMIC(ALenum) Connected;
+    ATOMIC(enum DeviceConnect) Connected;
     enum DeviceType Type;
 
     ALuint Frequency;

--- a/OpenAL32/alSource.c
+++ b/OpenAL32/alSource.c
@@ -2392,7 +2392,7 @@ AL_API ALvoid AL_APIENTRY alSourcePlayv(ALsizei n, const ALuint *sources)
     device = context->Device;
     ALCdevice_Lock(device);
     /* If the device is disconnected, go right to stopped. */
-    if(!ATOMIC_LOAD(&device->Connected, almemory_order_acquire))
+    if(ATOMIC_LOAD(&device->Connected, almemory_order_acquire) != DeviceConnect_Connected)
     {
         /* TODO: Send state change event? */
         for(i = 0;i < n;i++)


### PR DESCRIPTION
If the device is disconnected, as detected using:
`alcGetIntegerv(m_Device, ALC_CONNECTED, 1, &Connected); `

the application can call `alcResetDeviceSOFT()`: it will try and succeed if the device has been reconnected.
The application then needs to reset the sources state as desired (by calling `alSourcePlay()`, ...).
