### PR TITLE
Fix Resample_bsinc_SSE pointer casts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,7 @@ int main()
 IF(HAVE___BUILTIN_ASSUME_ALIGNED)
     SET(ASSUME_ALIGNED_DECL "__builtin_assume_aligned(x, y)")
 ELSE()
-    SET(ASSUME_ALIGNED_DECL "x")
+    SET(ASSUME_ALIGNED_DECL "(x)")
 ENDIF()
 
 SET(SSE_SWITCH "")


### PR DESCRIPTION
Regression was introduced in 5ec11a017c.

On MSVC there was this macro in config.h:

```
#define ASSUME_ALIGNED(x, y) x
```

While it was `ASSUME_ALIGNED(filter + offset, 16)` it was expanded to `filter + offset`, adding `offset * sizeof(*filter)` bytes to the `filter` pointer value.

But after it became `(const __m128*)ASSUME_ALIGNED(filter + offset, 16)` it was expanded to `(const __m128*)filter + offset`, adding `offset * sizeof(__m128)` bytes to the `filter` pointer value and completely killing captured data on Windows :(

PS macros are evil :)
