### PR TITLE
Fix compiling problems on VS2019 with vc142 toolset

### DIFF
--- a/Alc/alc.cpp
+++ b/Alc/alc.cpp
@@ -2312,6 +2312,7 @@ static DeviceRef VerifyDevice(ALCdevice *device)
 
 ALCcontext::ALCcontext(ALCdevice *device) : Device{device}
 {
+    PropsClean.test_and_set();
 }
 
 /* InitContext

--- a/Alc/alcontext.h
+++ b/Alc/alcontext.h
@@ -80,7 +80,7 @@ struct ALCcontext {
     ALfloat SpeedOfSound{};
     ALfloat MetersPerUnit{1.0f};
 
-    std::atomic_flag PropsClean{true};
+    std::atomic_flag PropsClean;
     std::atomic<bool> DeferUpdates{false};
 
     std::mutex PropLock;

--- a/OpenAL32/Include/alAuxEffectSlot.h
+++ b/OpenAL32/Include/alAuxEffectSlot.h
@@ -73,7 +73,7 @@ struct ALeffectslot {
         EffectState *State{nullptr};
     } Effect;
 
-    std::atomic_flag PropsClean{true};
+    std::atomic_flag PropsClean;
 
     RefCount ref{0u};
 
@@ -113,7 +113,7 @@ struct ALeffectslot {
      */
     alignas(16) ALfloat WetBuffer[MAX_EFFECT_CHANNELS][BUFFERSIZE];
 
-    ALeffectslot() = default;
+    ALeffectslot() { PropsClean.test_and_set(); }
     ALeffectslot(const ALeffectslot&) = delete;
     ALeffectslot& operator=(const ALeffectslot&) = delete;
     ~ALeffectslot();

--- a/OpenAL32/Include/alListener.h
+++ b/OpenAL32/Include/alListener.h
@@ -30,7 +30,7 @@ struct ALlistener {
     std::array<ALfloat,3> OrientUp{{0.0f, 1.0f, 0.0f}};
     ALfloat Gain{1.0f};
 
-    std::atomic_flag PropsClean{true};
+    std::atomic_flag PropsClean;
 
     /* Pointer to the most recent property values that are awaiting an update.
      */
@@ -50,6 +50,8 @@ struct ALlistener {
         ALboolean SourceDistanceModel;
         DistanceModel mDistanceModel;
     } Params;
+
+    ALlistener() { PropsClean.test_and_set(); }
 };
 
 void UpdateListenerProps(ALCcontext *context);

--- a/OpenAL32/Include/alSource.h
+++ b/OpenAL32/Include/alSource.h
@@ -98,7 +98,7 @@ struct ALsource {
     /** Source Buffer Queue head. */
     ALbufferlistitem *queue;
 
-    std::atomic_flag PropsClean{true};
+    std::atomic_flag PropsClean;
 
     /* Index into the context's Voices array. Lazily updated, only checked and
      * reset when looking up the voice.

--- a/OpenAL32/alSource.cpp
+++ b/OpenAL32/alSource.cpp
@@ -3353,6 +3353,8 @@ ALsource::ALsource(ALsizei num_sends)
     queue = nullptr;
 
     VoiceIdx = -1;
+
+    PropsClean.test_and_set();
 }
 
 ALsource::~ALsource()


### PR DESCRIPTION
Msvc142 in VS2019 preview 2 doesn't allow std::atomic_flag to be initialized by a bool. Call test_and_set in the constructors instead.