### PR TITLE
Remove some possible sources of crash

### DIFF
--- a/Alc/backends/null.cpp
+++ b/Alc/backends/null.cpp
@@ -96,7 +96,7 @@ int NullBackend::mixerProc()
          * and current time from growing too large, while maintaining the
          * correct number of samples to render.
          */
-        if(done >= mDevice->Frequency)
+        if(done >= mDevice->Frequency && mDevice->Frequency != 0)
         {
             seconds s{done/mDevice->Frequency};
             start += s;

--- a/Alc/backends/wave.cpp
+++ b/Alc/backends/wave.cpp
@@ -182,7 +182,7 @@ int WaveBackend::mixerProc()
          * and current time from growing too large, while maintaining the
          * correct number of samples to render.
          */
-        if(done >= mDevice->Frequency)
+        if(done >= mDevice->Frequency && mDevice->Frequency != 0)
         {
             seconds s{done/mDevice->Frequency};
             start += s;

--- a/OpenAL32/alSource.cpp
+++ b/OpenAL32/alSource.cpp
@@ -54,6 +54,9 @@ using namespace std::placeholders;
 
 inline ALvoice *GetSourceVoice(ALsource *source, ALCcontext *context)
 {
+    if(!source || !context)
+        return nullptr;
+
     ALint idx{source->VoiceIdx};
     if(idx >= 0 && idx < context->VoiceCount.load(std::memory_order_relaxed))
     {
@@ -2703,9 +2706,12 @@ AL_API ALvoid AL_APIENTRY alSourcePlayv(ALsizei n, const ALuint *sources)
             [&context](ALuint sid) -> void
             {
                 ALsource *source{LookupSource(context.get(), sid)};
-                source->OffsetType = AL_NONE;
-                source->Offset = 0.0;
-                source->state = AL_STOPPED;
+                if(source)
+                {
+                    source->OffsetType = AL_NONE;
+                    source->Offset = 0.0;
+                    source->state = AL_STOPPED;
+                }
             }
         );
         return;
@@ -2723,6 +2729,9 @@ AL_API ALvoid AL_APIENTRY alSourcePlayv(ALsizei n, const ALuint *sources)
     auto start_source = [&context,device](ALuint sid) -> void
     {
         ALsource *source{LookupSource(context.get(), sid)};
+        if(!source)
+            return;
+
         /* Check that there is a queue containing at least one valid, non zero
          * length buffer.
          */


### PR DESCRIPTION
It's possible to catch these scenarios (nullptr deference / dividing by zero) using clang-analyzer.