### PR TITLE
Move BackendListEnd variable from global scope to function scope.

### DIFF
--- a/Alc/alc.cpp
+++ b/Alc/alc.cpp
@@ -178,7 +178,6 @@ BackendInfo BackendList[] = {
     { "wave", WaveBackendFactory::getFactory },
 #endif
 };
-auto BackendListEnd = std::end(BackendList);
 
 BackendInfo PlaybackBackend;
 BackendInfo CaptureBackend;
@@ -943,6 +942,7 @@ static void alc_initconfig(void)
         else ERR("Failed to open log file '%s'\n", str);
     }
 
+    auto BackendListEnd = std::end(BackendList);
     TRACE("Initializing library v%s-%s %s\n", ALSOFT_VERSION,
           ALSOFT_GIT_COMMIT_HASH, ALSOFT_GIT_BRANCH);
     {


### PR DESCRIPTION
It reduces the scope of this variable to the function it is used, which
is cleaner.

It also avoid using the variable before it has been initialized.
Cf  StackOverflow: https://stackoverflow.com/a/25009120/5112390
~~~
The standard says that all objects are initialized in the same
translation unit (aka object file which corresponds to a single source
file) before any function is called in that translation unit.

The standard is allowing lazy initialization to occur in the event that
a DLL is loaded at run time. If you allow run-time linkage of your code,
you can't say that everything is initialized before main().
~~~

Bug: https://github.com/kcat/openal-soft/issues/288