### PR TITLE
Fix ambiguous calls to destroy_at

### DIFF
--- a/common/almalloc.h
+++ b/common/almalloc.h
@@ -85,7 +85,7 @@ inline void destroy(T first, const T end)
 {
     while(first != end)
     {
-        destroy_at(std::addressof(*first));
+        al::destroy_at(std::addressof(*first));
         ++first;
     }
 }
@@ -96,7 +96,7 @@ inline T destroy_n(T first, N count)
     if(count != 0)
     {
         do {
-            destroy_at(std::addressof(*first));
+            al::destroy_at(std::addressof(*first));
             ++first;
         } while(--count);
     }


### PR DESCRIPTION
Strangely, building ``common/almalloc.cpp`` from ``master`` under LLVM 8.0.0 gives me an ambiguous call to ``destroy_at`` in the header. The compiler can't decide between the function from ``<memory>`` and the one from ``al`` namespace. I presume the intention was to call the latter, so I've just preffixed the call with ``al::`` to resolve the error.

For reference, here is the error log:

```
FAILED: src/3rdparty/openal-soft/CMakeFiles/OpenAL.dir/Alc/mastering.cpp.o
/usr/bin/clang++  -DAL_ALEXT_PROTOTYPES -DAL_BUILD_LIBRARY -DAL_LIBTYPE_STATIC -DLIBM_COMPILING_FLT32 -DLUA_USE_LINUX -DPLATFORM_UNIX=1 -DSTREFLOP_SSE -D_LARGEFILE_SOURCE -D_LARGE_FILES -D_POSIX_C_SOURCE=200112L -D_SILENCE_CXX17_CODECVT_HEA
DER_DEPRECATION_WARNING -D_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING -D_SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING -D_XOPEN_SOURCE=600 -Igenerators_output -I../../src/3rdparty/ogg/include -Isrc/3rdparty/ogg/include -I.
./../src/3rdparty/vorbis/lib/../include -I../../src/3rdparty/vorbis/lib/. -I../../src/3rdparty/openal-soft/include -Isrc/3rdparty/openal-soft -I../../src/3rdparty/openal-soft/Alc -I../../src/3rdparty/openal-soft/OpenAL32/Include -I../../src
/3rdparty/openal-soft/common -std=c++11   -m64 -Xclang -fno-threadsafe-statics  -Wall -Wextra  -fcolor-diagnostics -Wno-error=unused-command-line-argument -Wno-error=missing-braces -ftemplate-backtrace-limit=0 -std=gnu++1z -stdlib=libc++
-Xclang -O0   -Winline -Wall -Wextra -fno-math-errno -fvisibility=hidden -pthread -MD -MT src/3rdparty/openal-soft/CMakeFiles/OpenAL.dir/Alc/mastering.cpp.o -MF src/3rdparty/openal-soft/CMakeFiles/OpenAL.dir/Alc/mastering.cpp.o.d -o src/3rd
party/openal-soft/CMakeFiles/OpenAL.dir/Alc/mastering.cpp.o -c ../../src/3rdparty/openal-soft/Alc/mastering.cpp
In file included from ../../src/3rdparty/openal-soft/Alc/mastering.cpp:8:
In file included from ../../src/3rdparty/openal-soft/Alc/mastering.h:8:
../../src/3rdparty/openal-soft/common/almalloc.h:99:13: error: call to 'destroy_at' is ambiguous
            destroy_at(std::addressof(*first));
            ^~~~~~~~~~
../../src/3rdparty/openal-soft/Alc/mastering.cpp:427:13: note: in instantiation of function template specialization 'al::destroy_n<std::__1::array<float, 1024> *, unsigned int, 0>' requested here
        al::destroy_n(mDelay, mNumChans);
            ^
/usr/bin/../include/c++/v1/memory:3325:6: note: candidate function [with _Tp = std::__1::array<float, 1024>]
void destroy_at(_Tp* __loc) {
     ^
../../src/3rdparty/openal-soft/common/almalloc.h:81:13: note: candidate function [with T = std::__1::array<float, 1024>]
inline void destroy_at(T *ptr) { ptr->~T(); }
            ^
1 error generated.
```