### PR TITLE
Fix the error "a reinterpret_cast is not a constant expression" in GCC 9

### DIFF
--- a/Alc/alc.cpp
+++ b/Alc/alc.cpp
@@ -188,7 +188,7 @@ BackendInfo CaptureBackend;
  * Functions, enums, and errors
  ************************************************/
 #define DECL(x) { #x, (ALCvoid*)(x) }
-constexpr struct {
+const struct {
     const ALCchar *funcName;
     ALCvoid *address;
 } alcFunctions[] = {


### PR DESCRIPTION
reinterpret_cast and C-style casting is no longer a constexpr in GCC9. Need to fall back to const instead.