### PR TITLE
Fixed makemhr and sofa-info errors

### DIFF
--- a/utils/makemhr/loaddef.cpp
+++ b/utils/makemhr/loaddef.cpp
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <cstdarg>
 #include <limits>
+#include <algorithm>
 
 #include "mysofa.h"
 

--- a/utils/sofa-info.cpp
+++ b/utils/sofa-info.cpp
@@ -207,9 +207,7 @@ static void PrintCompatibleLayout(const uint m, const float *xyzs)
         mysofa_c2s(&aers[i]);
     }
 
-    uint fdCount{GetUniquelySortedElems(m, aers.data(), 2,
-        (const float*[3]){ nullptr, nullptr, nullptr }, (const float[3]){ 0.1f, 0.1f, 0.001f },
-        elems.data())};
+    uint fdCount{GetUniquelySortedElems(m, aers.data(), 2, { nullptr, nullptr, nullptr }, { 0.1f, 0.1f, 0.001f }, elems.data())};
     if(fdCount > (m / 3))
     {
         fprintf(stdout, "Incompatible layout (inumerable radii).\n");
@@ -223,9 +221,7 @@ static void PrintCompatibleLayout(const uint m, const float *xyzs)
     for(uint fi{0u};fi < fdCount;fi++)
     {
         float dist{fds[fi].mDistance};
-        uint evCount{GetUniquelySortedElems(m, aers.data(), 1,
-            (const float*[3]){ nullptr, nullptr, &dist }, (const float[3]){ 0.1f, 0.1f, 0.001f },
-            elems.data())};
+        uint evCount{GetUniquelySortedElems(m, aers.data(), 1, { nullptr, nullptr, &dist }, { 0.1f, 0.1f, 0.001f }, elems.data())};
 
         if(evCount > (m / 3))
         {
@@ -268,9 +264,7 @@ static void PrintCompatibleLayout(const uint m, const float *xyzs)
         for(uint ei{evStart};ei < evCount;ei++)
         {
             float ev{-90.0f + ei * 180.0f / (evCount - 1)};
-            uint azCount{GetUniquelySortedElems(m, aers.data(), 0,
-                (const float*[3]){ nullptr, &ev, &dist }, (const float[3]){ 0.1f, 0.1f, 0.001f },
-                elems.data())};
+            uint azCount{GetUniquelySortedElems(m, aers.data(), 0, { nullptr, &ev, &dist }, { 0.1f, 0.1f, 0.001f }, elems.data())};
 
             if(azCount > (m / 3))
             {


### PR DESCRIPTION
Fixed some errors. This will allow you to build, but makemhr will fail if you do not add a directory containing getopt.h as an additional include.