### PR TITLE
pass proper effects slot number to AddActiveEffectSlots

### DIFF
--- a/al/auxeffectslot.cpp
+++ b/al/auxeffectslot.cpp
@@ -280,7 +280,8 @@ START_API_FUNC
     else
     {
         al::vector<ALuint> ids;
-        ids.reserve(static_cast<ALuint>(n));
+        ALsizei count{n};
+        ids.reserve(static_cast<ALuint>(count));
         do {
             ALeffectslot *slot{AllocEffectSlot(context.get())};
             if(!slot)
@@ -290,7 +291,7 @@ START_API_FUNC
                 return;
             }
             ids.emplace_back(slot->id);
-        } while(--n);
+        } while(--count);
         std::copy(ids.cbegin(), ids.cend(), effectslots);
     }
 


### PR DESCRIPTION
It resolves wrong logic when creating more than 1 aux slot at time in a batch