### PR TITLE
removed unnecessary loop

### DIFF
--- a/common/alcomplex.cpp
+++ b/common/alcomplex.cpp
@@ -55,8 +55,6 @@ void complex_fft(const al::span<std::complex<double>> buffer, const double sign)
 
 void complex_hilbert(const al::span<std::complex<double>> buffer)
 {
-    std::for_each(buffer.begin(), buffer.end(), [](std::complex<double> &c) { c.imag(0.0); });
-
     complex_fft(buffer, 1.0);
 
     const double inverse_size = 1.0/static_cast<double>(buffer.size());


### PR DESCRIPTION
the caller in fshifter is already doing the same job by putting 0 for the imaginary part