### PR TITLE
EFX: Modulator fix

### DIFF
--- a/alc/effects/modulator.cpp
+++ b/alc/effects/modulator.cpp
@@ -52,7 +52,7 @@ inline float Saw(ALuint index)
 { return static_cast<float>(index)*(2.0f/WAVEFORM_FRACONE) - 1.0f; }
 
 inline float Square(ALuint index)
-{ return static_cast<float>(((index>>(WAVEFORM_FRACBITS-2))&2) - 1); }
+{ return static_cast<float>(static_cast<int>((index>>(WAVEFORM_FRACBITS-2))&2) - 1); }
 
 inline float One(ALuint) { return 1.0f; }
 


### PR DESCRIPTION
MSVC 2015 and above returns the expression according to its datatype.
In this case, `((index>>(WAVEFORM_FRACBITS-2))&2)` returns 4294967295 instead of -1, with the result that one can imagine.

One example,  in the issue #351, PenguinDOOM made binaries for testing with MSVC 2017. These binaries are affected.

Please, review and merge it, thanks.