### PR TITLE
Don't require a C++ compiler for native-tools

### DIFF
--- a/native-tools/CMakeLists.txt
+++ b/native-tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 
-project(native-tools)
+project(native-tools C)
 
 include(CheckLibraryExists)
 


### PR DESCRIPTION
"By default C and CXX are enabled if no language options are given."
https://cmake.org/cmake/help/v3.17/command/project.html

I have ran into problems when cross-compiling inside of a Docker container where there's only a C compiler installed.