### PR TITLE
Fix find_package_handle_standard_args name mismatch warnings

### DIFF
--- a/cmake/FindDSound.cmake
+++ b/cmake/FindDSound.cmake
@@ -9,7 +9,7 @@
 #
 
 if (WIN32)
-  include(FindWindowsSDK)
+  FIND_PACKAGE(WindowsSDK)
   if (WINDOWSSDK_FOUND)
     get_windowssdk_library_dirs(${WINDOWSSDK_PREFERRED_DIR} WINSDK_LIB_DIRS)
     get_windowssdk_include_dirs(${WINDOWSSDK_PREFERRED_DIR} WINSDK_INCLUDE_DIRS)

--- a/cmake/FindMySOFA.cmake
+++ b/cmake/FindMySOFA.cmake
@@ -56,7 +56,7 @@ find_library(MYSOFA_M_LIBRARY NAMES m
 # handle the QUIETLY and REQUIRED arguments and set MYSOFA_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(MYSOFA REQUIRED_VARS MYSOFA_LIBRARY MYSOFA_INCLUDE_DIR ZLIB_FOUND)
+find_package_handle_standard_args(MySOFA REQUIRED_VARS MYSOFA_LIBRARY MYSOFA_INCLUDE_DIR ZLIB_FOUND)
 
 if(MYSOFA_FOUND)
     set(MYSOFA_INCLUDE_DIRS ${MYSOFA_INCLUDE_DIR})

--- a/cmake/FindOpenSL.cmake
+++ b/cmake/FindOpenSL.cmake
@@ -53,7 +53,7 @@ find_library(OPENSL_LIBRARY NAMES OpenSLES
 # handle the QUIETLY and REQUIRED arguments and set OPENSL_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(OPENSL REQUIRED_VARS OPENSL_LIBRARY OPENSL_INCLUDE_DIR
+find_package_handle_standard_args(OpenSL REQUIRED_VARS OPENSL_LIBRARY OPENSL_INCLUDE_DIR
     OPENSL_ANDROID_INCLUDE_DIR)
 
 if(OPENSL_FOUND)


### PR DESCRIPTION
Using CMake 3.17.0 with the Visual Studio 2019 generator, I get warnings during configuration about names passed to `find_package_handle_standard_args()`. While I am able to generate a sln file, it fails to open properly.

Two warnings are caused by case issues, and a third is caused by including the `FindWindowsSDK.cmake` file instead of calling `FIND_PACKAGE()`.

My changes fix these warnings and allow me to generate a sln file for openal-soft that opens successfully.