### PR TITLE
Add missing <cstdarg>

### DIFF
--- a/utils/makemhr/loaddef.cpp
+++ b/utils/makemhr/loaddef.cpp
@@ -26,13 +26,14 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
-#include <cstring>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <cstdarg>
 #include <vector>
 
 #include "alfstream.h"

--- a/utils/openal-info.c
+++ b/utils/openal-info.c
@@ -22,9 +22,10 @@
  * THE SOFTWARE.
  */
 
+#include <stdarg.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "AL/alc.h"
 #include "AL/al.h"


### PR DESCRIPTION
OpenAL-Soft failed to compile on some GCC version:
https://travis-ci.com/github/ArthurSonzogni/smk/jobs/318304162

It has regressed likely after:
https://github.com/kcat/openal-soft/commit/c83609277bed4be4ef40ed306bf2c57fefa19519

va_start is defined in:
- stdarg.h
- cstdarg

The repository is using it from:
- al/error.cpp
- al/filter.cpp
- alc/alu.cpp
- alc/helpers.cpp
- common/alexcpt.cpp
- utils/makemhr/loaddef.cpp
- utils/openal-info.c

This patch is adding its definition in the files missing it:
- utils/makemhr/loaddef.cpp
- utils/openal-info.c

Bug: https://github.com/kcat/openal-soft/issues/413