### PR TITLE
Added the possibility to change output device with JACK

### DIFF
--- a/alc/backends/jack.cpp
+++ b/alc/backends/jack.cpp
@@ -483,14 +483,14 @@ void JackPlayback::start()
         if(ports == nullptr)
         {
             jack_deactivate(mClient);
-            throw al::backend_exception{ALC_INVALID_DEVICE, "No physical playback ports found"};
+            throw al::backend_exception{ALC_INVALID_DEVICE, "No playback ports found"};
         }
         auto connect_port = [this](const jack_port_t *port, const char *pname) -> bool
         {
             if(!port) return false;
             if(!pname)
             {
-                ERR("No physical playback port for \"%s\"\n", jack_port_name(port));
+                ERR("No playback port for \"%s\"\n", jack_port_name(port));
                 return false;
             }
             if(jack_connect(mClient, jack_port_name(port), pname))

--- a/alc/backends/jack.cpp
+++ b/alc/backends/jack.cpp
@@ -453,8 +453,7 @@ void JackPlayback::start()
     const char *devname{mDevice->DeviceName.c_str()};
     if(ConfigValueBool(devname, "jack", "connect-ports").value_or(true))
     {
-        const char **ports{jack_get_ports(mClient, mPortPattern.c_str(), nullptr,
-            JackPortIsPhysical|JackPortIsInput)};
+        const char **ports{jack_get_ports(mClient, mPortPattern.c_str(), nullptr, JackPortIsInput)};
         if(ports == nullptr)
         {
             jack_deactivate(mClient);

--- a/alc/backends/jack.cpp
+++ b/alc/backends/jack.cpp
@@ -511,7 +511,14 @@ std::string JackBackendFactory::probe(BackendType type)
         const char **ports{jack_get_ports(client, nullptr, nullptr, JackPortIsPhysical|JackPortIsInput)};
         for (int i = 0; ports && ports[i] ; i++) {
             const char* colon = strchr(ports[i], ':');
-            int len = static_cast<int>  (colon - ports[i]);
+            int len;
+            if (colon != nullptr) {
+                len = static_cast<int>  (colon - ports[i]) + 1;
+            }
+            else {
+                len = strlen(ports[i]);
+            }
+            
             if (outnames.find(ports[i], 0, len) == std::string::npos) {
                 outnames.append(ports[i], len);
                 outnames.append(1, '\0');

--- a/alc/backends/jack.h
+++ b/alc/backends/jack.h
@@ -14,6 +14,10 @@ public:
     BackendPtr createBackend(ALCdevice *device, BackendType type) override;
 
     static BackendFactory &getFactory();
+
+private:
+	std::vector<std::string> device_list_names;
+	std::vector<std::string> device_list;
 };
 
 #endif /* BACKENDS_JACK_H */

--- a/alsoftrc.sample
+++ b/alsoftrc.sample
@@ -487,7 +487,7 @@
 ## custom-devices:
 #  Additionaly to physical devices, allow to add custom device defined by
 #  port name patterns separated by semicolon.
-#  For example : JACK Input Client:in;ardour:OpenAL/audio_in
+#  For example : OBS=JACK Input Client:in;Ardour=ardour:OpenAL/audio_in
 #custom-devices =
 
 ##

--- a/alsoftrc.sample
+++ b/alsoftrc.sample
@@ -484,6 +484,12 @@
 #  mixer time to keep enough audio available for the processing requests.
 #buffer-size = 0
 
+## custom-devices:
+#  Additionaly to physical devices, allow to add custom device defined by
+#  port name patterns separated by semicolon.
+#  For example : JACK Input Client:in;ardour:OpenAL/audio_in
+#custom-devices =
+
 ##
 ## WASAPI backend stuff
 ##

--- a/utils/alsoft-config/mainwindow.cpp
+++ b/utils/alsoft-config/mainwindow.cpp
@@ -448,6 +448,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->jackAutospawnCheckBox, &QCheckBox::stateChanged, this, &MainWindow::enableApplyButton);
     connect(ui->jackConnectPortsCheckBox, &QCheckBox::stateChanged, this, &MainWindow::enableApplyButton);
     connect(ui->jackBufferSizeSlider, &QSlider::valueChanged, this, &MainWindow::updateJackBufferSizeEdit);
+    connect(ui->jackCustomDevicesLine, &QLineEdit::textChanged, this, &MainWindow::enableApplyButton);
     connect(ui->jackBufferSizeLine, &QLineEdit::editingFinished, this, &MainWindow::updateJackBufferSizeSlider);
 
     connect(ui->alsaDefaultDeviceLine, &QLineEdit::textChanged, this, &MainWindow::enableApplyButton);
@@ -919,6 +920,7 @@ void MainWindow::loadConfig(const QString &fname)
 
     ui->jackAutospawnCheckBox->setCheckState(getCheckState(settings.value("jack/spawn-server")));
     ui->jackConnectPortsCheckBox->setCheckState(getCheckState(settings.value("jack/connect-ports")));
+    ui->jackCustomDevicesLine->setText(settings.value("jack/custom-devices", QString()).toString());
     ui->jackBufferSizeLine->setText(settings.value("jack/buffer-size", QString()).toString());
     updateJackBufferSizeSlider();
 
@@ -1129,6 +1131,7 @@ void MainWindow::saveConfig(const QString &fname) const
 
     settings.setValue("jack/spawn-server", getCheckValue(ui->jackAutospawnCheckBox));
     settings.setValue("jack/connect-ports", getCheckValue(ui->jackConnectPortsCheckBox));
+    settings.setValue("jack/custom-devices", ui->jackCustomDevicesLine->text());
     settings.setValue("jack/buffer-size", ui->jackBufferSizeLine->text());
 
     settings.setValue("alsa/device", ui->alsaDefaultDeviceLine->text());

--- a/utils/alsoft-config/mainwindow.ui
+++ b/utils/alsoft-config/mainwindow.ui
@@ -1442,7 +1442,7 @@ drop-outs.</string>
         <property name="geometry">
          <rect>
           <x>10</x>
-          <y>70</y>
+          <y>100</y>
           <width>401</width>
           <height>80</height>
          </rect>
@@ -1514,6 +1514,29 @@ processing requests. Must be a power of 2.</string>
         </property>
         <property name="tristate">
          <bool>true</bool>
+        </property>
+       </widget>
+       <widget class="QLineEdit" name="jackCustomDevicesLine">
+        <property name="geometry">
+         <rect>
+          <x>130</x>
+          <y>70</y>
+          <width>261</width>
+          <height>21</height>
+         </rect>
+        </property>
+       </widget>
+       <widget class="QLabel" name="label_33">
+        <property name="geometry">
+         <rect>
+          <x>15</x>
+          <y>70</y>
+          <width>121</width>
+          <height>19</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Custom devices:</string>
         </property>
        </widget>
       </widget>


### PR DESCRIPTION
This modification change the way the JACK backend choose wich ports to connect the same way VLC do to allow the choice of the output device :
If no device is given it choose to start on "system", the default JACK ouput.
If a device is specified, it use jack_get_ports to enumerate ports.
For example if device="ardour:AL/audio_in", it will connect to : 
ardour:AL/audio_in 1
ardour:AL/audio_in 2

For JackBackendFactory::probe, I've still have an hesitaion :
JACK can enumerate all ports, however it can't list devices.
Shoud JackBackendFactory::probe give :
- only "system" ?
- all ports (currently what my modification do) ?
- JACK client names ? (ex : "Ardour", "system") But some clients (like Ardour) have too many ports, it will not connect to the correct ports.
- or we try recover port groups (ex : "ardour:AL/audio_in") But for this solution, we need to list how channels can be named by clients (Ardour, alsa_out and JACK use 1/2 ; JACK mixer uses L/R ; the JACK sink Pulseaudio module uses left/right...).