### PR TITLE
Silence warning about unused return values

### DIFF
--- a/alc/hrtf.cpp
+++ b/alc/hrtf.cpp
@@ -895,7 +895,7 @@ std::unique_ptr<HrtfStore> LoadHrtf02(std::istream &data, const char *filename)
             elevs__end = std::copy_backward(elevs_src, elevs_src+field.evCount, elevs__end);
             return ebase + field.evCount;
         };
-        std::accumulate(fields.cbegin(), fields.cend(), ptrdiff_t{0}, copy_azs);
+        (void)std::accumulate(fields.cbegin(), fields.cend(), ptrdiff_t{0}, copy_azs);
         assert(elevs_.begin() == elevs__end);
 
         /* Reestablish the IR offset for each elevation index, given the new
@@ -930,7 +930,7 @@ std::unique_ptr<HrtfStore> LoadHrtf02(std::istream &data, const char *filename)
 
             return ebase + field.evCount;
         };
-        std::accumulate(fields.cbegin(), fields.cend(), ptrdiff_t{0}, copy_irs);
+        (void)std::accumulate(fields.cbegin(), fields.cend(), ptrdiff_t{0}, copy_irs);
         assert(coeffs_.begin() == coeffs_end);
         assert(delays_.begin() == delays_end);
 

--- a/alc/panning.cpp
+++ b/alc/panning.cpp
@@ -976,7 +976,7 @@ void aluInitRenderer(ALCdevice *device, int hrtf_id, HrtfRequestMode hrtf_appreq
             device->HrtfName = hrtfname;
             return true;
         };
-        std::find_if(device->HrtfList.cbegin(), device->HrtfList.cend(), find_hrtf);
+        (void)std::find_if(device->HrtfList.cbegin(), device->HrtfList.cend(), find_hrtf);
     }
 
     if(device->mHrtf)


### PR DESCRIPTION
When compiling with MSVC 2019 I'm getting the following warning at these 3 locations:

`warning C4834: discarding return value of function with 'nodiscard' attribute`