### PR TITLE
Add a gain argument to altonegen

### DIFF
--- a/alc/backends/opensl.cpp
+++ b/alc/backends/opensl.cpp
@@ -252,7 +252,7 @@ int OpenSLPlayback::mixerProc()
             }
             if(SL_RESULT_SUCCESS != result)
             {
-                mDevice->handleDisconnect("Failed to start platback: 0x%08x", result);
+                mDevice->handleDisconnect("Failed to start playback: 0x%08x", result);
                 break;
             }
 

--- a/examples/altonegen.c
+++ b/examples/altonegen.c
@@ -44,7 +44,9 @@
 
 #include "common/alhelpers.h"
 
-#include "win_main_utf8.h"
+#ifdef _WIN32
+# include "win_main_utf8.h"
+#endif
 
 #ifndef M_PI
 #define M_PI    (3.14159265358979323846)
@@ -93,7 +95,7 @@ static void ApplySin(ALfloat *data, ALdouble g, ALuint srate, ALuint freq)
 /* Generates waveforms using additive synthesis. Each waveform is constructed
  * by summing one or more sine waves, up to (and excluding) nyquist.
  */
-static ALuint CreateWave(enum WaveType type, ALuint freq, ALuint srate)
+static ALuint CreateWave(enum WaveType type, ALuint freq, ALuint srate, ALfloat gain)
 {
     ALuint seed = 22222;
     ALuint data_size;
@@ -144,6 +146,10 @@ static ALuint CreateWave(enum WaveType type, ALuint freq, ALuint srate)
             break;
     }
 
+	if (gain != 1.0)
+		for(i = 0;i < srate;i++)
+			data[i] *= gain;
+
     /* Buffer the audio data into a new buffer object. */
     buffer = 0;
     alGenBuffers(1, &buffer);
@@ -175,6 +181,7 @@ int main(int argc, char *argv[])
     ALint tone_freq = 1000;
     ALCint dev_rate;
     ALenum state;
+	ALfloat gain = 1.0f;
     int i;
 
     argv++; argc--;
@@ -190,7 +197,9 @@ int main(int argc, char *argv[])
 
     for(i = 0;i < argc;i++)
     {
-        if(strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0)
+        if (strcmp(argv[i], "-h") == 0
+		 || strcmp(argv[i], "-?") == 0
+		 || strcmp(argv[i], "--help") == 0)
         {
             fprintf(stderr, "OpenAL Tone Generator\n"
 "\n"
@@ -202,6 +211,7 @@ int main(int argc, char *argv[])
 "  --waveform/-w <type>      Waveform type: sine (default), square, sawtooth,\n"
 "                                triangle, impulse, noise\n"
 "  --freq/-f <hz>            Tone frequency (default 1000 hz)\n"
+"  --gain/-g <gain>          gain 0.0 to 1 (default 1)\n"
 "  --srate/-s <sample rate>  Sampling rate (default output rate)\n",
                 appname
             );
@@ -241,6 +251,16 @@ int main(int argc, char *argv[])
                 tone_freq = 1;
             }
         }
+        else if(i+1 < argc && (strcmp(argv[i], "--gain") == 0 || strcmp(argv[i], "-g") == 0))
+        {
+            i++;
+            gain = atof(argv[i]);
+            if(gain < 0.0 || gain > 1.0)
+            {
+                fprintf(stderr, "Invalid gain: %s (min: 0.0, max 1.0)\n", argv[i]);
+                tone_freq = 1;
+            }
+        }
         else if(i+1 < argc && (strcmp(argv[i], "--srate") == 0 || strcmp(argv[i], "-s") == 0))
         {
             i++;
@@ -262,7 +282,7 @@ int main(int argc, char *argv[])
         srate = dev_rate;
 
     /* Load the sound into a buffer. */
-    buffer = CreateWave(wavetype, (ALuint)tone_freq, (ALuint)srate);
+    buffer = CreateWave(wavetype, (ALuint)tone_freq, (ALuint)srate, gain);
     if(!buffer)
     {
         CloseAL();

--- a/examples/altonegen.c
+++ b/examples/altonegen.c
@@ -146,9 +146,9 @@ static ALuint CreateWave(enum WaveType type, ALuint freq, ALuint srate, ALfloat 
             break;
     }
 
-	if (gain != 1.0)
-		for(i = 0;i < srate;i++)
-			data[i] *= gain;
+    if (gain != 1.0)
+	for(i = 0;i < srate;i++)
+	    data[i] *= gain;
 
     /* Buffer the audio data into a new buffer object. */
     buffer = 0;
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
     ALint tone_freq = 1000;
     ALCint dev_rate;
     ALenum state;
-	ALfloat gain = 1.0f;
+    ALfloat gain = 1.0f;
     int i;
 
     argv++; argc--;
@@ -198,8 +198,8 @@ int main(int argc, char *argv[])
     for(i = 0;i < argc;i++)
     {
         if (strcmp(argv[i], "-h") == 0
-		 || strcmp(argv[i], "-?") == 0
-		 || strcmp(argv[i], "--help") == 0)
+	 || strcmp(argv[i], "-?") == 0
+	 || strcmp(argv[i], "--help") == 0)
         {
             fprintf(stderr, "OpenAL Tone Generator\n"
 "\n"
@@ -255,10 +255,10 @@ int main(int argc, char *argv[])
         {
             i++;
             gain = atof(argv[i]);
-            if(gain < 0.0 || gain > 1.0)
+            if (gain < 0.0f || gain > 1.0f)
             {
                 fprintf(stderr, "Invalid gain: %s (min: 0.0, max 1.0)\n", argv[i]);
-                tone_freq = 1;
+                gain = 1.0f;
             }
         }
         else if(i+1 < argc && (strcmp(argv[i], "--srate") == 0 || strcmp(argv[i], "-s") == 0))


### PR DESCRIPTION
Add a gain command-line argument to altonegen.c.
Fix a spelling error in an error message in opensl.cpp
Fix compilation of some of the examples by guarding the include of win_main_utf8.h