### PR TITLE
Fix windowsAPI issue with min/max

### DIFF
--- a/al/buffer.cpp
+++ b/al/buffer.cpp
@@ -537,7 +537,7 @@ void LoadData(ALCcontext *context, ALbuffer *ALBuf, ALsizei freq, ALuint size,
             "Data size %d is not a multiple of frame size %d (%d unpack alignment)",
             size, SrcByteAlign, align);
 
-    if UNLIKELY(size/SrcByteAlign > std::numeric_limits<ALsizei>::max()/align)
+    if UNLIKELY(size/SrcByteAlign > (std::numeric_limits<ALsizei>::max)()/align)
         SETERR_RETURN(context, AL_OUT_OF_MEMORY,,
             "Buffer size overflow, %d blocks x %d samples per block", size/SrcByteAlign, align);
     const ALuint frames{size / SrcByteAlign * align};
@@ -547,7 +547,7 @@ void LoadData(ALCcontext *context, ALbuffer *ALBuf, ALsizei freq, ALuint size,
      */
     ALuint NumChannels{ChannelsFromFmt(DstChannels, ambiorder)};
     ALuint FrameSize{NumChannels * BytesFromFmt(DstType)};
-    if UNLIKELY(frames > std::numeric_limits<size_t>::max()/FrameSize)
+    if UNLIKELY(frames > (std::numeric_limits<size_t>::max)()/FrameSize)
         SETERR_RETURN(context, AL_OUT_OF_MEMORY,,
             "Buffer size overflow, %d frames x %d bytes per frame", frames, FrameSize);
     size_t newsize{static_cast<size_t>(frames) * FrameSize};

--- a/al/source.cpp
+++ b/al/source.cpp
@@ -434,13 +434,13 @@ al::optional<VoicePos> GetSampleOffset(al::deque<ALbufferQueueItem> &BufferList,
     {
     case AL_SEC_OFFSET:
         dblfrac = std::modf(Offset*BufferFmt->mSampleRate, &dbloff);
-        offset = static_cast<ALuint>(mind(dbloff, std::numeric_limits<ALuint>::max()));
+        offset = static_cast<ALuint>(mind(dbloff, (std::numeric_limits<ALuint>::max)()));
         frac = static_cast<ALuint>(mind(dblfrac*MixerFracOne, MixerFracOne-1.0));
         break;
 
     case AL_SAMPLE_OFFSET:
         dblfrac = std::modf(Offset, &dbloff);
-        offset = static_cast<ALuint>(mind(dbloff, std::numeric_limits<ALuint>::max()));
+        offset = static_cast<ALuint>(mind(dbloff, (std::numeric_limits<ALuint>::max)()));
         frac = static_cast<ALuint>(mind(dblfrac*MixerFracOne, MixerFracOne-1.0));
         break;
 
@@ -2095,7 +2095,7 @@ bool GetSourceiv(ALsource *Source, ALCcontext *Context, SourceProp prop, const a
     case AL_SEC_LENGTH_SOFT:
         CHECKSIZE(values, 1);
         values[0] = static_cast<int>(mind(GetSourceLength(Source, prop),
-            std::numeric_limits<int>::max()));
+            (std::numeric_limits<int>::max)()));
         return true;
 
     case AL_SOURCE_RESAMPLER_SOFT:

--- a/al/source.h
+++ b/al/source.h
@@ -46,7 +46,7 @@ struct ALsource {
     float InnerAngle{360.0f};
     float OuterAngle{360.0f};
     float RefDistance{1.0f};
-    float MaxDistance{std::numeric_limits<float>::max()};
+    float MaxDistance{(std::numeric_limits<float>::max)()};
     float RolloffFactor{1.0f};
     std::array<float,3> Position{{0.0f, 0.0f, 0.0f}};
     std::array<float,3> Velocity{{0.0f, 0.0f, 0.0f}};

--- a/alc/alc.cpp
+++ b/alc/alc.cpp
@@ -2662,7 +2662,7 @@ static size_t GetIntegerv(ALCdevice *device, ALCenum param, const al::span<int> 
             std::lock_guard<std::mutex> _{device->StateLock};
             device->enumerateHrtfs();
             values[0] = static_cast<int>(minz(device->mHrtfList.size(),
-                std::numeric_limits<int>::max()));
+                (std::numeric_limits<int>::max)()));
         }
         return 1;
 

--- a/alc/backends/coreaudio.cpp
+++ b/alc/backends/coreaudio.cpp
@@ -589,7 +589,7 @@ void CoreAudioCapture::open(const char *name)
     auto FrameCount64 = maxu64(static_cast<uint64_t>(std::ceil(mDevice->BufferSize*srateScale)),
         static_cast<UInt32>(outputFormat.mSampleRate)/10);
     FrameCount64 += MaxResamplerPadding;
-    if(FrameCount64 > std::numeric_limits<int32_t>::max())
+    if(FrameCount64 > std::numeric_limits<int32_t>::max(())
         throw al::backend_exception{al::backend_error::DeviceError,
             "Calculated frame count is too large: %" PRIu64, FrameCount64};
 

--- a/alc/backends/pulseaudio.cpp
+++ b/alc/backends/pulseaudio.cpp
@@ -1023,7 +1023,7 @@ bool PulsePlayback::reset()
         const auto perlen = static_cast<uint>(clampd(scale*mDevice->UpdateSize + 0.5, 64.0,
             8192.0));
         const auto buflen = static_cast<uint>(clampd(scale*mDevice->BufferSize + 0.5, perlen*2,
-            std::numeric_limits<int>::max()/mFrameSize));
+            (std::numeric_limits<int>::max)()/mFrameSize));
 
         mAttr.maxlength = ~0u;
         mAttr.tlength = buflen * mFrameSize;
@@ -1403,7 +1403,7 @@ uint PulseCapture::availableSamples()
         }
     }
 
-    readable = std::min<size_t>(readable, std::numeric_limits<uint>::max());
+    readable = std::min<size_t>(readable, (std::numeric_limits<uint>::max)());
     mLastReadable = std::max(mLastReadable, static_cast<uint>(readable));
     return mLastReadable / static_cast<uint>(pa_frame_size(&mSpec));
 }

--- a/alc/backends/wasapi.cpp
+++ b/alc/backends/wasapi.cpp
@@ -126,7 +126,7 @@ constexpr DWORD X71Mask{MaskFromTopBits(X7DOT1)};
 inline uint RefTime2Samples(const ReferenceTime &val, uint srate)
 {
     const auto retval = (val*srate + ReferenceTime{seconds{1}}/2) / seconds{1};
-    return static_cast<uint>(mini64(retval, std::numeric_limits<uint>::max()));
+    return static_cast<uint>(mini64(retval, (std::numeric_limits<uint>::max)()));
 }
 
 

--- a/alc/context.cpp
+++ b/alc/context.cpp
@@ -204,7 +204,7 @@ void ContextBase::allocVoices(size_t addcount)
     /* Convert element count to cluster count. */
     addcount = (addcount+(clustersize-1)) / clustersize;
 
-    if(addcount >= std::numeric_limits<int>::max()/clustersize - mVoiceClusters.size())
+    if(addcount >= (std::numeric_limits<int>::max)()/clustersize - mVoiceClusters.size())
         throw std::runtime_error{"Allocating too many voices"};
     const size_t totalcount{(mVoiceClusters.size()+addcount) * clustersize};
     TRACE("Increasing allocated voices to %zu\n", totalcount);

--- a/common/almalloc.h
+++ b/common/almalloc.h
@@ -88,7 +88,7 @@ struct allocator {
 
     T *allocate(std::size_t n)
     {
-        if(n > std::numeric_limits<std::size_t>::max()/sizeof(T)) throw std::bad_alloc();
+        if(n > (std::numeric_limits<std::size_t>::max)()/sizeof(T)) throw std::bad_alloc();
         if(auto p = al_malloc(alignment, n*sizeof(T))) return static_cast<T*>(p);
         throw std::bad_alloc();
     }

--- a/common/ringbuffer.cpp
+++ b/common/ringbuffer.cpp
@@ -45,7 +45,7 @@ RingBufferPtr RingBuffer::Create(size_t sz, size_t elem_sz, int limit_writes)
 #endif
     }
     ++power_of_two;
-    if(power_of_two <= sz || power_of_two > std::numeric_limits<size_t>::max()/elem_sz)
+    if(power_of_two <= sz || power_of_two > (std::numeric_limits<size_t>::max)()/elem_sz)
         throw std::overflow_error{"Ring buffer size overflow"};
 
     const size_t bufbytes{power_of_two * elem_sz};

--- a/common/threads.cpp
+++ b/common/threads.cpp
@@ -64,9 +64,9 @@ namespace al {
 
 semaphore::semaphore(unsigned int initial)
 {
-    if(initial > static_cast<unsigned int>(std::numeric_limits<int>::max()))
+    if(initial > static_cast<unsigned int>((std::numeric_limits<int>::max)()))
         throw std::system_error(std::make_error_code(std::errc::value_too_large));
-    mSem = CreateSemaphore(nullptr, initial, std::numeric_limits<int>::max(), nullptr);
+    mSem = CreateSemaphore(nullptr, initial, (std::numeric_limits<int>::max)(), nullptr);
     if(mSem == nullptr)
         throw std::system_error(std::make_error_code(std::errc::resource_unavailable_try_again));
 }

--- a/core/converter.cpp
+++ b/core/converter.cpp
@@ -217,7 +217,7 @@ uint SampleConverter::availableOut(uint srcframes) const
 
     /* If we have a full prep, we can generate at least one sample. */
     return static_cast<uint>(clampu64((DataSize64 + mIncrement-1)/mIncrement, 1,
-        std::numeric_limits<int>::max()));
+        (std::numeric_limits<int>::max)()));
 }
 
 uint SampleConverter::convert(const void **src, uint *srcframes, void *dst, uint dstframes)

--- a/core/helpers.cpp
+++ b/core/helpers.cpp
@@ -451,7 +451,7 @@ void SetRTPriority()
                 if(rlim.rlim_max > umaxtime)
                 {
                     rlim.rlim_max = static_cast<rlim_t>(std::min<ulonglong>(umaxtime,
-                        std::numeric_limits<rlim_t>::max()));
+                        (std::numeric_limits<rlim_t>::max)()));
                     rlim.rlim_cur = std::min(rlim.rlim_cur, rlim.rlim_max);
                     if(setrlimit(RLIMIT_RTTIME, &rlim) != 0)
                         return errno;

--- a/examples/alffplay.cpp
+++ b/examples/alffplay.cpp
@@ -295,7 +295,7 @@ struct AudioState {
     nanoseconds mCurrentPts{0};
 
     /* Device clock time that the stream started at. */
-    nanoseconds mDeviceStartTime{nanoseconds::min()};
+    nanoseconds mDeviceStartTime{(nanoseconds::min)()};
 
     /* Decompressed sample frame, and swresample context for conversion */
     AVFramePtr    mDecodedFrame;
@@ -378,7 +378,7 @@ struct VideoState {
      * was last updated - used to have running video pts
      */
     nanoseconds mDisplayPts{0};
-    microseconds mDisplayPtsTime{microseconds::min()};
+    microseconds mDisplayPtsTime{(microseconds::min)()};
     std::mutex mDispPtsMutex;
 
     /* Swscale context for format conversion */
@@ -386,7 +386,7 @@ struct VideoState {
 
     struct Picture {
         AVFramePtr mFrame{};
-        nanoseconds mPts{nanoseconds::min()};
+        nanoseconds mPts{(nanoseconds::min)()};
     };
     std::array<Picture,VIDEO_PICTURE_QUEUE_SIZE> mPictQ;
     std::atomic<size_t> mPictQRead{0u}, mPictQWrite{1u};
@@ -421,7 +421,7 @@ struct MovieState {
 
     SyncMaster mAVSyncType{SyncMaster::Default};
 
-    microseconds mClockBase{microseconds::min()};
+    microseconds mClockBase{(microseconds::min)()};
 
     std::atomic<bool> mQuit{false};
 
@@ -465,7 +465,7 @@ nanoseconds AudioState::getClockNoLock()
     if(alcGetInteger64vSOFT)
     {
         // If device start time = min, we aren't playing yet.
-        if(mDeviceStartTime == nanoseconds::min())
+        if(mDeviceStartTime == (nanoseconds::min)())
             return nanoseconds::zero();
 
         // Get the current device clock time and latency.
@@ -483,7 +483,7 @@ nanoseconds AudioState::getClockNoLock()
 
     if(mBufferDataSize > 0)
     {
-        if(mDeviceStartTime == nanoseconds::min())
+        if(mDeviceStartTime == (nanoseconds::min)())
             return nanoseconds::zero();
 
         /* With a callback buffer and no device clock, mDeviceStartTime is
@@ -1409,7 +1409,7 @@ nanoseconds VideoState::getClock()
 {
     /* NOTE: This returns incorrect times while not playing. */
     std::lock_guard<std::mutex> _{mDispPtsMutex};
-    if(mDisplayPtsTime == microseconds::min())
+    if(mDisplayPtsTime == (microseconds::min)())
         return nanoseconds::zero();
     auto delta = get_avtime() - mDisplayPtsTime;
     return mDisplayPts + delta;
@@ -1729,7 +1729,7 @@ void MovieState::setTitle(SDL_Window *window)
 
 nanoseconds MovieState::getClock()
 {
-    if(mClockBase == microseconds::min())
+    if(mClockBase == (microseconds::)min())
         return nanoseconds::zero();
     return get_avtime() - mClockBase;
 }
@@ -2069,7 +2069,7 @@ int main(int argc, char *argv[])
     enum class EomAction {
         Next, Quit
     } eom_action{EomAction::Next};
-    seconds last_time{seconds::min()};
+    seconds last_time{(seconds::min)()};
     while(1)
     {
         SDL_Event event{};
@@ -2130,7 +2130,7 @@ int main(int argc, char *argv[])
 
             case FF_MOVIE_DONE_EVENT:
                 std::cout<<'\n';
-                last_time = seconds::min();
+                last_time = (seconds::min)();
                 if(eom_action != EomAction::Quit)
                 {
                     movState = nullptr;

--- a/utils/makemhr/makemhr.cpp
+++ b/utils/makemhr/makemhr.cpp
@@ -211,7 +211,7 @@ static inline uint dither_rng(uint *seed)
 static void TpdfDither(double *RESTRICT out, const double *RESTRICT in, const double scale,
                        const uint count, const uint step, uint *seed)
 {
-    static constexpr double PRNG_SCALE = 1.0 / std::numeric_limits<uint>::max();
+    static constexpr double PRNG_SCALE = 1.0 / (std::numeric_limits<uint>::max)();
 
     for(uint i{0};i < count;i++)
     {


### PR DESCRIPTION
Fixes the issue with clang not compiling due to the WinAPI having defined min/max #566 
The other simpler solution is to define `NOMINMAX` but don't know where to start that, so just did what I could