### PR TITLE
Fix getting of device channel count in CoreAudio backend

### DIFF
--- a/alc/backends/coreaudio.cpp
+++ b/alc/backends/coreaudio.cpp
@@ -141,14 +141,13 @@ UInt32 GetDeviceChannelCount(AudioDeviceID devId, bool isCapture)
     }
 
     auto buffer_data = std::vector<char>(propSize);
-    AudioBufferList *buflist{::new(buffer_data.data()) AudioBufferList{}};
+    AudioBufferList *buflist{reinterpret_cast<AudioBufferList*>(buffer_data.data())};
 
     err = GetDevProperty(devId, kAudioDevicePropertyStreamConfiguration, isCapture, 0, propSize,
         buflist);
     if(err)
     {
         ERR("kAudioDevicePropertyStreamConfiguration query failed: %u\n", err);
-        al::destroy_at(buflist);
         return 0;
     }
 
@@ -156,7 +155,6 @@ UInt32 GetDeviceChannelCount(AudioDeviceID devId, bool isCapture)
     for(size_t i{0};i < buflist->mNumberBuffers;++i)
         numChannels += buflist->mBuffers[i].mNumberChannels;
 
-    al::destroy_at(buflist);
     return numChannels;
 }
 


### PR DESCRIPTION
AudioBufferList contains a variable length array of mNumberBuffers elements, so it should not be created with the default constructor like usual class instances.
Unfortunately, Apple developer site documentation is literally empty for this API. There is a bunch of comments in framework's header files.
Here is the correct usage of AudioBufferList pointer from Chromium: https://chromium.googlesource.com/chromium/src/media/+/008a1abc573e1f8bcf513b50ce48a923b30ef130/audio/mac/audio_manager_mac.cc#266
There were occasional crashes because of memory corruption which was confirmed by address sanitizer