### PR TITLE
Fixed compilation on compilers that use EDG C++ frontend

### DIFF
--- a/alc/effects/convolution.cpp
+++ b/alc/effects/convolution.cpp
@@ -131,11 +131,11 @@ void apply_fir(al::span<float> dst, const float *RESTRICT src, const float *REST
 #ifdef HAVE_SSE_INTRINSICS
     for(float &output : dst)
     {
-        __m128 r4{_mm_setzero_ps()};
+        __m128 r4 = _mm_setzero_ps();
         for(size_t j{0};j < ConvolveUpdateSamples;j+=4)
         {
-            const __m128 coeffs{_mm_load_ps(&filter[j])};
-            const __m128 s{_mm_loadu_ps(&src[j])};
+            const __m128 coeffs = _mm_load_ps(&filter[j]);
+            const __m128 s = _mm_loadu_ps(&src[j]);
 
             r4 = _mm_add_ps(r4, _mm_mul_ps(s, coeffs));
         }
@@ -150,7 +150,7 @@ void apply_fir(al::span<float> dst, const float *RESTRICT src, const float *REST
 
     for(float &output : dst)
     {
-        float32x4_t r4{vdupq_n_f32(0.0f)};
+        float32x4_t r4 = vdupq_n_f32(0.0f);
         for(size_t j{0};j < ConvolveUpdateSamples;j+=4)
             r4 = vmlaq_f32(r4, vld1q_f32(&src[j]), vld1q_f32(&filter[j]));
         r4 = vaddq_f32(r4, vrev64q_f32(r4));

--- a/common/phase_shifter.h
+++ b/common/phase_shifter.h
@@ -80,15 +80,15 @@ inline void PhaseShifterT<S>::process(al::span<float> dst, const float *RESTRICT
     {
         auto *out = reinterpret_cast<__m64*>(dst.data());
         do {
-            __m128 r04{_mm_setzero_ps()};
-            __m128 r14{_mm_setzero_ps()};
+            __m128 r04 = _mm_setzero_ps();
+            __m128 r14 = _mm_setzero_ps();
             for(size_t j{0};j < mCoeffs.size();j+=4)
             {
-                const __m128 coeffs{_mm_load_ps(&mCoeffs[j])};
-                const __m128 s0{_mm_loadu_ps(&src[j*2])};
-                const __m128 s1{_mm_loadu_ps(&src[j*2 + 4])};
+                const __m128 coeffs = _mm_load_ps(&mCoeffs[j]);
+                const __m128 s0 = _mm_loadu_ps(&src[j*2]);
+                const __m128 s1 = _mm_loadu_ps(&src[j*2 + 4]);
 
-                __m128 s{_mm_shuffle_ps(s0, s1, _MM_SHUFFLE(2, 0, 2, 0))};
+                __m128 s = _mm_shuffle_ps(s0, s1, _MM_SHUFFLE(2, 0, 2, 0));
                 r04 = _mm_add_ps(r04, _mm_mul_ps(s, coeffs));
 
                 s = _mm_shuffle_ps(s0, s1, _MM_SHUFFLE(3, 1, 3, 1));
@@ -96,7 +96,7 @@ inline void PhaseShifterT<S>::process(al::span<float> dst, const float *RESTRICT
             }
             src += 2;
 
-            __m128 r4{_mm_add_ps(_mm_unpackhi_ps(r04, r14), _mm_unpacklo_ps(r04, r14))};
+            __m128 r4 = _mm_add_ps(_mm_unpackhi_ps(r04, r14), _mm_unpacklo_ps(r04, r14));
             r4 = _mm_add_ps(r4, _mm_movehl_ps(r4, r4));
 
             _mm_storel_pi(out, r4);
@@ -105,11 +105,11 @@ inline void PhaseShifterT<S>::process(al::span<float> dst, const float *RESTRICT
     }
     if((dst.size()&1))
     {
-        __m128 r4{_mm_setzero_ps()};
+        __m128 r4 = _mm_setzero_ps();
         for(size_t j{0};j < mCoeffs.size();j+=4)
         {
-            const __m128 coeffs{_mm_load_ps(&mCoeffs[j])};
-            const __m128 s{_mm_setr_ps(src[j*2], src[j*2 + 2], src[j*2 + 4], src[j*2 + 6])};
+            const __m128 coeffs = _mm_load_ps(&mCoeffs[j]);
+            const __m128 s = _mm_setr_ps(src[j*2], src[j*2 + 2], src[j*2 + 4], src[j*2 + 6]);
             r4 = _mm_add_ps(r4, _mm_mul_ps(s, coeffs));
         }
         r4 = _mm_add_ps(r4, _mm_shuffle_ps(r4, r4, _MM_SHUFFLE(0, 1, 2, 3)));
@@ -128,7 +128,7 @@ inline void PhaseShifterT<S>::process(al::span<float> dst, const float *RESTRICT
          */
         auto shuffle_2020 = [](float32x4_t a, float32x4_t b)
         {
-            float32x4_t ret{vmovq_n_f32(vgetq_lane_f32(a, 0))};
+            float32x4_t ret = vmovq_n_f32(vgetq_lane_f32(a, 0));
             ret = vsetq_lane_f32(vgetq_lane_f32(a, 2), ret, 1);
             ret = vsetq_lane_f32(vgetq_lane_f32(b, 0), ret, 2);
             ret = vsetq_lane_f32(vgetq_lane_f32(b, 2), ret, 3);
@@ -136,7 +136,7 @@ inline void PhaseShifterT<S>::process(al::span<float> dst, const float *RESTRICT
         };
         auto shuffle_3131 = [](float32x4_t a, float32x4_t b)
         {
-            float32x4_t ret{vmovq_n_f32(vgetq_lane_f32(a, 1))};
+            float32x4_t ret = vmovq_n_f32(vgetq_lane_f32(a, 1));
             ret = vsetq_lane_f32(vgetq_lane_f32(a, 3), ret, 1);
             ret = vsetq_lane_f32(vgetq_lane_f32(b, 1), ret, 2);
             ret = vsetq_lane_f32(vgetq_lane_f32(b, 3), ret, 3);
@@ -153,20 +153,20 @@ inline void PhaseShifterT<S>::process(al::span<float> dst, const float *RESTRICT
             return vcombine_f32(result.val[0], result.val[1]);
         };
         do {
-            float32x4_t r04{vdupq_n_f32(0.0f)};
-            float32x4_t r14{vdupq_n_f32(0.0f)};
+            float32x4_t r04 = vdupq_n_f32(0.0f);
+            float32x4_t r14 = vdupq_n_f32(0.0f);
             for(size_t j{0};j < mCoeffs.size();j+=4)
             {
-                const float32x4_t coeffs{vld1q_f32(&mCoeffs[j])};
-                const float32x4_t s0{vld1q_f32(&src[j*2])};
-                const float32x4_t s1{vld1q_f32(&src[j*2 + 4])};
+                const float32x4_t coeffs = vld1q_f32(&mCoeffs[j]);
+                const float32x4_t s0 = vld1q_f32(&src[j*2]);
+                const float32x4_t s1 = vld1q_f32(&src[j*2 + 4]);
 
                 r04 = vmlaq_f32(r04, shuffle_2020(s0, s1), coeffs);
                 r14 = vmlaq_f32(r14, shuffle_3131(s0, s1), coeffs);
             }
             src += 2;
 
-            float32x4_t r4{vaddq_f32(unpackhi(r04, r14), unpacklo(r04, r14))};
+            float32x4_t r4 = vaddq_f32(unpackhi(r04, r14), unpacklo(r04, r14));
             float32x2_t r2{vadd_f32(vget_low_f32(r4), vget_high_f32(r4))};
 
             vst1_f32(&dst[pos], r2);
@@ -177,17 +177,17 @@ inline void PhaseShifterT<S>::process(al::span<float> dst, const float *RESTRICT
     {
         auto load4 = [](float32_t a, float32_t b, float32_t c, float32_t d)
         {
-            float32x4_t ret{vmovq_n_f32(a)};
+            float32x4_t ret = vmovq_n_f32(a);
             ret = vsetq_lane_f32(b, ret, 1);
             ret = vsetq_lane_f32(c, ret, 2);
             ret = vsetq_lane_f32(d, ret, 3);
             return ret;
         };
-        float32x4_t r4{vdupq_n_f32(0.0f)};
+        float32x4_t r4 = vdupq_n_f32(0.0f);
         for(size_t j{0};j < mCoeffs.size();j+=4)
         {
-            const float32x4_t coeffs{vld1q_f32(&mCoeffs[j])};
-            const float32x4_t s{load4(src[j*2], src[j*2 + 2], src[j*2 + 4], src[j*2 + 6])};
+            const float32x4_t coeffs = vld1q_f32(&mCoeffs[j]);
+            const float32x4_t s = load4(src[j*2], src[j*2 + 2], src[j*2 + 4], src[j*2 + 6]);
             r4 = vmlaq_f32(r4, s, coeffs);
         }
         r4 = vaddq_f32(r4, vrev64q_f32(r4));
@@ -216,15 +216,15 @@ inline void PhaseShifterT<S>::processAccum(al::span<float> dst, const float *RES
     {
         auto *out = reinterpret_cast<__m64*>(dst.data());
         do {
-            __m128 r04{_mm_setzero_ps()};
-            __m128 r14{_mm_setzero_ps()};
+            __m128 r04 = _mm_setzero_ps();
+            __m128 r14 = _mm_setzero_ps();
             for(size_t j{0};j < mCoeffs.size();j+=4)
             {
-                const __m128 coeffs{_mm_load_ps(&mCoeffs[j])};
-                const __m128 s0{_mm_loadu_ps(&src[j*2])};
-                const __m128 s1{_mm_loadu_ps(&src[j*2 + 4])};
+                const __m128 coeffs =_mm_load_ps(&mCoeffs[j]);
+                const __m128 s0 = _mm_loadu_ps(&src[j*2]);
+                const __m128 s1 = _mm_loadu_ps(&src[j*2 + 4]);
 
-                __m128 s{_mm_shuffle_ps(s0, s1, _MM_SHUFFLE(2, 0, 2, 0))};
+                __m128 s = _mm_shuffle_ps(s0, s1, _MM_SHUFFLE(2, 0, 2, 0));
                 r04 = _mm_add_ps(r04, _mm_mul_ps(s, coeffs));
 
                 s = _mm_shuffle_ps(s0, s1, _MM_SHUFFLE(3, 1, 3, 1));
@@ -232,7 +232,7 @@ inline void PhaseShifterT<S>::processAccum(al::span<float> dst, const float *RES
             }
             src += 2;
 
-            __m128 r4{_mm_add_ps(_mm_unpackhi_ps(r04, r14), _mm_unpacklo_ps(r04, r14))};
+            __m128 r4 = _mm_add_ps(_mm_unpackhi_ps(r04, r14), _mm_unpacklo_ps(r04, r14));
             r4 = _mm_add_ps(r4, _mm_movehl_ps(r4, r4));
 
             _mm_storel_pi(out, _mm_add_ps(_mm_loadl_pi(_mm_undefined_ps(), out), r4));
@@ -241,14 +241,14 @@ inline void PhaseShifterT<S>::processAccum(al::span<float> dst, const float *RES
     }
     if((dst.size()&1))
     {
-        __m128 r4{_mm_setzero_ps()};
+        __m128 r4 = _mm_setzero_ps();
         for(size_t j{0};j < mCoeffs.size();j+=4)
         {
-            const __m128 coeffs{_mm_load_ps(&mCoeffs[j])};
+            const __m128 coeffs = _mm_load_ps(&mCoeffs[j]);
             /* NOTE: This could alternatively be done with two unaligned loads
              * and a shuffle. Which would be better?
              */
-            const __m128 s{_mm_setr_ps(src[j*2], src[j*2 + 2], src[j*2 + 4], src[j*2 + 6])};
+            const __m128 s = _mm_setr_ps(src[j*2], src[j*2 + 2], src[j*2 + 4], src[j*2 + 6]);
             r4 = _mm_add_ps(r4, _mm_mul_ps(s, coeffs));
         }
         r4 = _mm_add_ps(r4, _mm_shuffle_ps(r4, r4, _MM_SHUFFLE(0, 1, 2, 3)));
@@ -264,7 +264,7 @@ inline void PhaseShifterT<S>::processAccum(al::span<float> dst, const float *RES
     {
         auto shuffle_2020 = [](float32x4_t a, float32x4_t b)
         {
-            float32x4_t ret{vmovq_n_f32(vgetq_lane_f32(a, 0))};
+            float32x4_t ret = vmovq_n_f32(vgetq_lane_f32(a, 0));
             ret = vsetq_lane_f32(vgetq_lane_f32(a, 2), ret, 1);
             ret = vsetq_lane_f32(vgetq_lane_f32(b, 0), ret, 2);
             ret = vsetq_lane_f32(vgetq_lane_f32(b, 2), ret, 3);
@@ -272,7 +272,7 @@ inline void PhaseShifterT<S>::processAccum(al::span<float> dst, const float *RES
         };
         auto shuffle_3131 = [](float32x4_t a, float32x4_t b)
         {
-            float32x4_t ret{vmovq_n_f32(vgetq_lane_f32(a, 1))};
+            float32x4_t ret = vmovq_n_f32(vgetq_lane_f32(a, 1));
             ret = vsetq_lane_f32(vgetq_lane_f32(a, 3), ret, 1);
             ret = vsetq_lane_f32(vgetq_lane_f32(b, 1), ret, 2);
             ret = vsetq_lane_f32(vgetq_lane_f32(b, 3), ret, 3);
@@ -289,20 +289,20 @@ inline void PhaseShifterT<S>::processAccum(al::span<float> dst, const float *RES
             return vcombine_f32(result.val[0], result.val[1]);
         };
         do {
-            float32x4_t r04{vdupq_n_f32(0.0f)};
-            float32x4_t r14{vdupq_n_f32(0.0f)};
+            float32x4_t r04 = vdupq_n_f32(0.0f);
+            float32x4_t r14 = vdupq_n_f32(0.0f);
             for(size_t j{0};j < mCoeffs.size();j+=4)
             {
-                const float32x4_t coeffs{vld1q_f32(&mCoeffs[j])};
-                const float32x4_t s0{vld1q_f32(&src[j*2])};
-                const float32x4_t s1{vld1q_f32(&src[j*2 + 4])};
+                const float32x4_t coeffs = vld1q_f32(&mCoeffs[j]);
+                const float32x4_t s0 = vld1q_f32(&src[j*2]);
+                const float32x4_t s1 = vld1q_f32(&src[j*2 + 4]);
 
                 r04 = vmlaq_f32(r04, shuffle_2020(s0, s1), coeffs);
                 r14 = vmlaq_f32(r14, shuffle_3131(s0, s1), coeffs);
             }
             src += 2;
 
-            float32x4_t r4{vaddq_f32(unpackhi(r04, r14), unpacklo(r04, r14))};
+            float32x4_t r4 = vaddq_f32(unpackhi(r04, r14), unpacklo(r04, r14));
             float32x2_t r2{vadd_f32(vget_low_f32(r4), vget_high_f32(r4))};
 
             vst1_f32(&dst[pos], vadd_f32(vld1_f32(&dst[pos]), r2));
@@ -313,17 +313,17 @@ inline void PhaseShifterT<S>::processAccum(al::span<float> dst, const float *RES
     {
         auto load4 = [](float32_t a, float32_t b, float32_t c, float32_t d)
         {
-            float32x4_t ret{vmovq_n_f32(a)};
+            float32x4_t ret = vmovq_n_f32(a);
             ret = vsetq_lane_f32(b, ret, 1);
             ret = vsetq_lane_f32(c, ret, 2);
             ret = vsetq_lane_f32(d, ret, 3);
             return ret;
         };
-        float32x4_t r4{vdupq_n_f32(0.0f)};
+        float32x4_t r4 = vdupq_n_f32(0.0f);
         for(size_t j{0};j < mCoeffs.size();j+=4)
         {
-            const float32x4_t coeffs{vld1q_f32(&mCoeffs[j])};
-            const float32x4_t s{load4(src[j*2], src[j*2 + 2], src[j*2 + 4], src[j*2 + 6])};
+            const float32x4_t coeffs = vld1q_f32(&mCoeffs[j]);
+            const float32x4_t s = load4(src[j*2], src[j*2 + 2], src[j*2 + 4], src[j*2 + 6]);
             r4 = vmlaq_f32(r4, s, coeffs);
         }
         r4 = vaddq_f32(r4, vrev64q_f32(r4));

--- a/core/mixer/mixer_neon.cpp
+++ b/core/mixer/mixer_neon.cpp
@@ -24,7 +24,7 @@ namespace {
 
 inline float32x4_t set_f4(float l0, float l1, float l2, float l3)
 {
-    float32x4_t ret{vmovq_n_f32(l0)};
+    float32x4_t ret = vmovq_n_f32(l0);
     ret = vsetq_lane_f32(l1, ret, 1);
     ret = vsetq_lane_f32(l2, ret, 2);
     ret = vsetq_lane_f32(l3, ret, 3);
@@ -79,13 +79,13 @@ float *Resample_<LerpTag,NEONTag>(const InterpState*, float *RESTRICT src, uint 
         const int pos1{vgetq_lane_s32(pos4, 1)};
         const int pos2{vgetq_lane_s32(pos4, 2)};
         const int pos3{vgetq_lane_s32(pos4, 3)};
-        const float32x4_t val1{set_f4(src[pos0], src[pos1], src[pos2], src[pos3])};
-        const float32x4_t val2{set_f4(src[pos0+1], src[pos1+1], src[pos2+1], src[pos3+1])};
+        const float32x4_t val1 = set_f4(src[pos0], src[pos1], src[pos2], src[pos3]);
+        const float32x4_t val2 = set_f4(src[pos0+1], src[pos1+1], src[pos2+1], src[pos3+1]);
 
         /* val1 + (val2-val1)*mu */
-        const float32x4_t r0{vsubq_f32(val2, val1)};
-        const float32x4_t mu{vmulq_f32(vcvtq_f32_s32(frac4), fracOne4)};
-        const float32x4_t out{vmlaq_f32(val1, mu, r0)};
+        const float32x4_t r0 = vsubq_f32(val2, val1);
+        const float32x4_t mu = vmulq_f32(vcvtq_f32_s32(frac4), fracOne4);
+        const float32x4_t out = vmlaq_f32(val1, mu, r0);
 
         vst1q_f32(dst_iter, out);
         dst_iter += 4;
@@ -116,7 +116,7 @@ float *Resample_<BSincTag,NEONTag>(const InterpState *state, float *RESTRICT src
     uint increment, const al::span<float> dst)
 {
     const float *const filter{state->bsinc.filter};
-    const float32x4_t sf4{vdupq_n_f32(state->bsinc.sf)};
+    const float32x4_t sf4 = vdupq_n_f32(state->bsinc.sf);
     const size_t m{state->bsinc.m};
     ASSUME(m > 0);
 
@@ -128,9 +128,9 @@ float *Resample_<BSincTag,NEONTag>(const InterpState *state, float *RESTRICT src
         const float pf{static_cast<float>(frac & (FracPhaseDiffOne-1)) * (1.0f/FracPhaseDiffOne)};
 
         // Apply the scale and phase interpolated filter.
-        float32x4_t r4{vdupq_n_f32(0.0f)};
+        float32x4_t r4 = vdupq_n_f32(0.0f);
         {
-            const float32x4_t pf4{vdupq_n_f32(pf)};
+            const float32x4_t pf4 = vdupq_n_f32(pf);
             const float *RESTRICT fil{filter + m*pi*2};
             const float *RESTRICT phd{fil + m};
             const float *RESTRICT scd{fil + BSincPhaseCount*2*m};
@@ -174,9 +174,9 @@ float *Resample_<FastBSincTag,NEONTag>(const InterpState *state, float *RESTRICT
         const float pf{static_cast<float>(frac & (FracPhaseDiffOne-1)) * (1.0f/FracPhaseDiffOne)};
 
         // Apply the phase interpolated filter.
-        float32x4_t r4{vdupq_n_f32(0.0f)};
+        float32x4_t r4 = vdupq_n_f32(0.0f);
         {
-            const float32x4_t pf4{vdupq_n_f32(pf)};
+            const float32x4_t pf4 = vdupq_n_f32(pf);
             const float *RESTRICT fil{filter + m*pi*2};
             const float *RESTRICT phd{fil + m};
             size_t td{m >> 2};
@@ -247,10 +247,10 @@ void Mix_<NEONTag>(const al::span<const float> InSamples, const al::span<FloatBu
             /* Mix with applying gain steps in aligned multiples of 4. */
             if(size_t todo{(min_len-pos) >> 2})
             {
-                const float32x4_t four4{vdupq_n_f32(4.0f)};
-                const float32x4_t step4{vdupq_n_f32(step)};
-                const float32x4_t gain4{vdupq_n_f32(gain)};
-                float32x4_t step_count4{vdupq_n_f32(0.0f)};
+                const float32x4_t four4 = vdupq_n_f32(4.0f);
+                const float32x4_t step4 = vdupq_n_f32(step);
+                const float32x4_t gain4 = vdupq_n_f32(gain);
+                float32x4_t step_count4 = vdupq_n_f32(0.0f);
                 step_count4 = vsetq_lane_f32(1.0f, step_count4, 1);
                 step_count4 = vsetq_lane_f32(2.0f, step_count4, 2);
                 step_count4 = vsetq_lane_f32(3.0f, step_count4, 3);

--- a/core/mixer/mixer_sse2.cpp
+++ b/core/mixer/mixer_sse2.cpp
@@ -38,16 +38,16 @@ template<>
 float *Resample_<LerpTag,SSE2Tag>(const InterpState*, float *RESTRICT src, uint frac,
     uint increment, const al::span<float> dst)
 {
-    const __m128i increment4{_mm_set1_epi32(static_cast<int>(increment*4))};
-    const __m128 fracOne4{_mm_set1_ps(1.0f/MixerFracOne)};
-    const __m128i fracMask4{_mm_set1_epi32(MixerFracMask)};
+    const __m128i increment4 = _mm_set1_epi32(static_cast<int>(increment*4));
+    const __m128 fracOne4 = _mm_set1_ps(1.0f/MixerFracOne);
+    const __m128i fracMask4 = _mm_set1_epi32(MixerFracMask);
 
     alignas(16) uint pos_[4], frac_[4];
     InitPosArrays(frac, increment, frac_, pos_);
-    __m128i frac4{_mm_setr_epi32(static_cast<int>(frac_[0]), static_cast<int>(frac_[1]),
-        static_cast<int>(frac_[2]), static_cast<int>(frac_[3]))};
-    __m128i pos4{_mm_setr_epi32(static_cast<int>(pos_[0]), static_cast<int>(pos_[1]),
-        static_cast<int>(pos_[2]), static_cast<int>(pos_[3]))};
+    __m128i frac4 = _mm_setr_epi32(static_cast<int>(frac_[0]), static_cast<int>(frac_[1]),
+        static_cast<int>(frac_[2]), static_cast<int>(frac_[3]));
+    __m128i pos4 = _mm_setr_epi32(static_cast<int>(pos_[0]), static_cast<int>(pos_[1]),
+        static_cast<int>(pos_[2]), static_cast<int>(pos_[3]));
 
     auto dst_iter = dst.begin();
     for(size_t todo{dst.size()>>2};todo;--todo)
@@ -56,13 +56,13 @@ float *Resample_<LerpTag,SSE2Tag>(const InterpState*, float *RESTRICT src, uint 
         const int pos1{_mm_cvtsi128_si32(_mm_srli_si128(pos4, 4))};
         const int pos2{_mm_cvtsi128_si32(_mm_srli_si128(pos4, 8))};
         const int pos3{_mm_cvtsi128_si32(_mm_srli_si128(pos4, 12))};
-        const __m128 val1{_mm_setr_ps(src[pos0  ], src[pos1  ], src[pos2  ], src[pos3  ])};
-        const __m128 val2{_mm_setr_ps(src[pos0+1], src[pos1+1], src[pos2+1], src[pos3+1])};
+        const __m128 val1 = _mm_setr_ps(src[pos0  ], src[pos1  ], src[pos2  ], src[pos3  ]);
+        const __m128 val2 = _mm_setr_ps(src[pos0+1], src[pos1+1], src[pos2+1], src[pos3+1]);
 
         /* val1 + (val2-val1)*mu */
-        const __m128 r0{_mm_sub_ps(val2, val1)};
-        const __m128 mu{_mm_mul_ps(_mm_cvtepi32_ps(frac4), fracOne4)};
-        const __m128 out{_mm_add_ps(val1, _mm_mul_ps(mu, r0))};
+        const __m128 r0 = _mm_sub_ps(val2, val1);
+        const __m128 mu = _mm_mul_ps(_mm_cvtepi32_ps(frac4), fracOne4);
+        const __m128 out = _mm_add_ps(val1, _mm_mul_ps(mu, r0));
 
         _mm_store_ps(dst_iter, out);
         dst_iter += 4;

--- a/core/mixer/mixer_sse41.cpp
+++ b/core/mixer/mixer_sse41.cpp
@@ -39,16 +39,16 @@ template<>
 float *Resample_<LerpTag,SSE4Tag>(const InterpState*, float *RESTRICT src, uint frac,
     uint increment, const al::span<float> dst)
 {
-    const __m128i increment4{_mm_set1_epi32(static_cast<int>(increment*4))};
-    const __m128 fracOne4{_mm_set1_ps(1.0f/MixerFracOne)};
-    const __m128i fracMask4{_mm_set1_epi32(MixerFracMask)};
+    const __m128i increment4 = _mm_set1_epi32(static_cast<int>(increment*4));
+    const __m128 fracOne4 = _mm_set1_ps(1.0f/MixerFracOne);
+    const __m128i fracMask4 = _mm_set1_epi32(MixerFracMask);
 
     alignas(16) uint pos_[4], frac_[4];
     InitPosArrays(frac, increment, frac_, pos_);
-    __m128i frac4{_mm_setr_epi32(static_cast<int>(frac_[0]), static_cast<int>(frac_[1]),
-        static_cast<int>(frac_[2]), static_cast<int>(frac_[3]))};
-    __m128i pos4{_mm_setr_epi32(static_cast<int>(pos_[0]), static_cast<int>(pos_[1]),
-        static_cast<int>(pos_[2]), static_cast<int>(pos_[3]))};
+    __m128i frac4 = _mm_setr_epi32(static_cast<int>(frac_[0]), static_cast<int>(frac_[1]),
+        static_cast<int>(frac_[2]), static_cast<int>(frac_[3]));
+    __m128i pos4 = _mm_setr_epi32(static_cast<int>(pos_[0]), static_cast<int>(pos_[1]),
+        static_cast<int>(pos_[2]), static_cast<int>(pos_[3]));
 
     auto dst_iter = dst.begin();
     for(size_t todo{dst.size()>>2};todo;--todo)
@@ -57,13 +57,13 @@ float *Resample_<LerpTag,SSE4Tag>(const InterpState*, float *RESTRICT src, uint 
         const int pos1{_mm_extract_epi32(pos4, 1)};
         const int pos2{_mm_extract_epi32(pos4, 2)};
         const int pos3{_mm_extract_epi32(pos4, 3)};
-        const __m128 val1{_mm_setr_ps(src[pos0  ], src[pos1  ], src[pos2  ], src[pos3  ])};
-        const __m128 val2{_mm_setr_ps(src[pos0+1], src[pos1+1], src[pos2+1], src[pos3+1])};
+        const __m128 val1 = _mm_setr_ps(src[pos0  ], src[pos1  ], src[pos2  ], src[pos3  ]);
+        const __m128 val2 = _mm_setr_ps(src[pos0+1], src[pos1+1], src[pos2+1], src[pos3+1]);
 
         /* val1 + (val2-val1)*mu */
-        const __m128 r0{_mm_sub_ps(val2, val1)};
-        const __m128 mu{_mm_mul_ps(_mm_cvtepi32_ps(frac4), fracOne4)};
-        const __m128 out{_mm_add_ps(val1, _mm_mul_ps(mu, r0))};
+        const __m128 r0 = _mm_sub_ps(val2, val1);
+        const __m128 mu = _mm_mul_ps(_mm_cvtepi32_ps(frac4), fracOne4);
+        const __m128 out = _mm_add_ps(val1, _mm_mul_ps(mu, r0));
 
         _mm_store_ps(dst_iter, out);
         dst_iter += 4;


### PR DESCRIPTION
The Edison Design Group frontend used in MCST lcc compiler as well as Intel C++ compiler and some others. We faced a problem when lcc was complaining that "no suitable conversion function from "__m128" to "float"". It could not digest uniform construction of _m128 from another _m128 due to a bug in the EDG frontend.
So here I replaced uniform initialization of __m128 and __m128i with assignment.