### PR TITLE
Fix crashes in SndioCapture::recordProc

### DIFF
--- a/alc/backends/sndio.cpp
+++ b/alc/backends/sndio.cpp
@@ -311,6 +311,8 @@ int SndioCapture::recordProc()
 
     const uint frameSize{mDevice->frameSizeFromFmt()};
 
+    mFds.reserve(sio_nfds(mSndHandle));
+
     while(!mKillNow.load(std::memory_order_acquire)
         && mDevice->Connected.load(std::memory_order_acquire))
     {

--- a/alc/backends/sndio.cpp
+++ b/alc/backends/sndio.cpp
@@ -311,7 +311,14 @@ int SndioCapture::recordProc()
 
     const uint frameSize{mDevice->frameSizeFromFmt()};
 
-    mFds.reserve(sio_nfds(mSndHandle));
+    int nfds_pre{sio_nfds(mSndHandle)};
+    if (nfds_pre <= 0)
+    {
+        mDevice->handleDisconnect("Incorrect return value from sio_nfds(): %d", nfds_pre);
+        return 1;
+    }
+
+    mFds.resize(nfds_pre);
 
     while(!mKillNow.load(std::memory_order_acquire)
         && mDevice->Connected.load(std::memory_order_acquire))


### PR DESCRIPTION
Hello! I found a crashes of applications while capturing audio using openal with the sndio backend. I also discovered a fix for this.

Problem description:

OpenBSD 7.0 (current), sndio.
openal 1.21.1 + 620836f173ae6fc4505d0634984e0f2c46166367 and 1fd4c865fc084f134363db5155361d5483679235 (the most recent commit in alc/backends/sndio.cpp for now).

```
> ./alrecord -device "SndIO Default" -o ./test.wav
Opened "SndIO Default"
Recording './test.wav', Signed 16-bit, Mono, 44100hz (4 seconds)
Captured 0 samples[ALSOFT] (EE) Cannot set priority level for thread
zsh: segmentation fault (core dumped)  ./alrecord -device "SndIO Default" -o ./test.wav

(gdb) bt
#0  _aucat_pollfd (hdl=0xc58eb866ea0, pfd=0x0, events=1) at /usr/src/lib/libsndio/aucat.c:561
#1  0x00000c59601f665b in (anonymous namespace)::SndioCapture::recordProc () from /usr/local/lib/libopenal.so.4.1
#2  0x00000c59601f6833 in _ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEENS_8__mem_fnIMN12_GLOBAL__N_112SndioCaptureEFivEEEPS9_EEEEEPvSF_ () from /usr/local/lib/libopenal.so.4.1
#3  0x00000c58fcabf801 in _rthread_start (v=Unhandled dwarf expression opcode 0xa3
) at /usr/src/lib/librthread/rthread.c:96
#4  0x00000c592d52dd2a in __tfork_thread () at /usr/src/lib/libc/arch/amd64/sys/tfork_thread.S:84
#5  0x00000c592d52dd2a in __tfork_thread () at /usr/src/lib/libc/arch/amd64/sys/tfork_thread.S:84
Previous frame identical to this frame (corrupt stack?)
(gdb) 
```
According to the [documentation](https://man.openbsd.org/sio_open):
> The size of the pfd array, which the caller must pre-allocate, is provided by the sio_nfds() function.

> The sio_nfds() function returns the number of pollfd structures the caller must preallocate in order to be sure that sio_pollfd() will never overrun.

My micro-patch adds the missing allocation. After applying it, the problem stopped reproducing for me:
```
> ./alrecord -device "SndIO Default" -o ./test.wav
Opened "SndIO Default"
Recording './test.wav', Signed 16-bit, Mono, 44100hz (4 seconds)
Captured 0 samples[ALSOFT] (EE) Cannot set priority level for thread
Captured 176841 samples
[ALSOFT] (II) Freeing device 0xb3b9604000
```
Just in case: I am not a member of the OpenBSD project, only a user.