### PR TITLE
Fix cone angle calculation

### DIFF
--- a/alc/alu.cpp
+++ b/alc/alu.cpp
@@ -1386,7 +1386,7 @@ void CalcAttnSourceParams(Voice *voice, const VoiceProps *props, const ContextBa
     /* Calculate directional soundcones */
     if(directional && props->InnerAngle < 360.0f)
     {
-        const float Angle{Rad2Deg(std::acos(Direction.dot_product(ToSource)) * ConeScale * -2.0f)};
+        const float Angle{Rad2Deg(std::acos(-Direction.dot_product(ToSource)) * ConeScale * 2.0f)};
 
         float ConeGain, ConeHF;
         if(!(Angle > props->InnerAngle))


### PR DESCRIPTION
It seems like a recent change to cone angle calculation broke the cone feature, as I found out after an updated build of openal-soft broke cones in a project I was working on. 
A quick debugging session showed angles to be negative numbers, which caused a gain of 1.0f to be used regardless of the actual angle. This fix addresses that, instead inverting the dot product of the two normals to achieve the desired angle and correct gain.
