### PR TITLE
Remove extra ';' after member function definition

### DIFF
--- a/core/fpu_ctrl.h
+++ b/core/fpu_ctrl.h
@@ -8,7 +8,7 @@ class FPUCtl {
     bool in_mode{};
 
 public:
-    FPUCtl() noexcept { enter(); in_mode = true; };
+    FPUCtl() noexcept { enter(); in_mode = true; }
     ~FPUCtl() { if(in_mode) leave(); }
 
     FPUCtl(const FPUCtl&) = delete;


### PR DESCRIPTION
Found using -Wextra-semi warning.