### PR TITLE
Fixed compiler warning on MSVC

### DIFF
--- a/al/event.cpp
+++ b/al/event.cpp
@@ -201,7 +201,7 @@ START_API_FUNC
         /* Wait to ensure the event handler sees the changed flags before
          * returning.
          */
-        std::lock_guard<std::mutex>{context->mEventCbLock};
+        std::lock_guard<std::mutex> _{context->mEventCbLock};
     }
 }
 END_API_FUNC


### PR DESCRIPTION
MSVC produced the warning `openal-soft\al\event.cpp(204,36): warning C4834: discarding return value of function with 'nodiscard' attribute` due to the unnamed std::lock_guard