### PR TITLE
[EAX] Add primary extension name fro EAX v2.0

### DIFF
--- a/al/eax_globals.cpp
+++ b/al/eax_globals.cpp
@@ -6,7 +6,8 @@
 bool eax_g_is_enabled = true;
 
 
-const char* eax_v2_0_ext_name = "EAX2.0";
+const char* eax_v2_0_ext_name_1 = "EAX";
+const char* eax_v2_0_ext_name_2 = "EAX2.0";
 const char* eax_v3_0_ext_name = "EAX3.0";
 const char* eax_v4_0_ext_name = "EAX4.0";
 const char* eax_v5_0_ext_name = "EAX5.0";

--- a/al/eax_globals.h
+++ b/al/eax_globals.h
@@ -5,7 +5,8 @@
 extern bool eax_g_is_enabled;
 
 
-extern const char* eax_v2_0_ext_name;
+extern const char* eax_v2_0_ext_name_1;
+extern const char* eax_v2_0_ext_name_2;
 extern const char* eax_v3_0_ext_name;
 extern const char* eax_v4_0_ext_name;
 extern const char* eax_v5_0_ext_name;

--- a/al/extension.cpp
+++ b/al/extension.cpp
@@ -48,7 +48,8 @@ START_API_FUNC
 
     size_t len{strlen(extName)};
 #ifdef ALSOFT_EAX
-    if (al::strcasecmp(eax_v2_0_ext_name, extName) == 0 ||
+    if (al::strcasecmp(eax_v2_0_ext_name_1, extName) == 0 ||
+        al::strcasecmp(eax_v2_0_ext_name_2, extName) == 0 ||
         al::strcasecmp(eax_v3_0_ext_name, extName) == 0 ||
         al::strcasecmp(eax_v4_0_ext_name, extName) == 0 ||
         al::strcasecmp(eax_v5_0_ext_name, extName) == 0)

--- a/alc/context.cpp
+++ b/alc/context.cpp
@@ -626,7 +626,8 @@ void ALCcontext::eax_initialize_extensions()
 
     const auto string_max_capacity =
         std::strlen(mExtensionList) + 1 +
-        std::strlen(eax_v2_0_ext_name) + 1 +
+        std::strlen(eax_v2_0_ext_name_1) + 1 +
+        std::strlen(eax_v2_0_ext_name_2) + 1 +
         std::strlen(eax_v3_0_ext_name) + 1 +
         std::strlen(eax_v4_0_ext_name) + 1 +
         std::strlen(eax_v5_0_ext_name) + 1 +
@@ -637,7 +638,10 @@ void ALCcontext::eax_initialize_extensions()
 
     if (eax_is_capable())
     {
-        eax_extension_list_ += eax_v2_0_ext_name;
+        eax_extension_list_ += eax_v2_0_ext_name_1;
+        eax_extension_list_ += ' ';
+
+        eax_extension_list_ += eax_v2_0_ext_name_2;
         eax_extension_list_ += ' ';
 
         eax_extension_list_ += eax_v3_0_ext_name;


### PR DESCRIPTION
Seems the extension name `EAX2.0` was introduced later.
The manual uses name `EAX` to query for the extension presence.