### PR TITLE
constexpr functions are not allowed to have static variables, and if they are constexpr anyways then them being static has no benifit

### DIFF
--- a/common/albit.h
+++ b/common/albit.h
@@ -99,10 +99,10 @@ constexpr std::enable_if_t<std::is_integral<T>::value && std::is_unsigned<T>::va
 int> popcount(T val) noexcept
 {
     using fast_type = typename detail_::fast_utype<T>::type;
-    static constexpr fast_type b01010101{detail_::repbits<fast_type>(0x55)};
-    static constexpr fast_type b00110011{detail_::repbits<fast_type>(0x33)};
-    static constexpr fast_type b00001111{detail_::repbits<fast_type>(0x0f)};
-    static constexpr fast_type b00000001{detail_::repbits<fast_type>(0x01)};
+    constexpr fast_type b01010101{detail_::repbits<fast_type>(0x55)};
+    constexpr fast_type b00110011{detail_::repbits<fast_type>(0x33)};
+    constexpr fast_type b00001111{detail_::repbits<fast_type>(0x0f)};
+    constexpr fast_type b00000001{detail_::repbits<fast_type>(0x01)};
 
     fast_type v{fast_type{val} - ((fast_type{val} >> 1) & b01010101)};
     v = (v & b00110011) + ((v >> 2) & b00110011);


### PR DESCRIPTION
static variables are not permitted in `constexpr` functions. Unlike with functions, `constexpr` is not a suggestion with variables, and need to evaluate to a constant expression. So making them static when they are generated at compile time will have no additional performance benefit within a local scope.

It is also better to have non static `constexpr` variables in a `constexpr` function than `constexpr` variables in a non `constexpr` function because it allows the functions to be completely optimized away, including the existence of the variable.
![image](https://user-images.githubusercontent.com/50330170/160595479-8d9a02bb-30de-4619-8a5c-1d8a568f467d.png)
![image](https://user-images.githubusercontent.com/50330170/160595495-93e2a7e5-4db9-4c04-8d9c-592bd3fcad1d.png)
Yes with optimization turned off the `constexpr` function has 1 more line of unnecessary ASM, but with any optimization at all the `constexpr` functions dissapears. (The generated example generates the same ASM with -O1 and -O2, and similar behaviour for other compilers)
