### PR TITLE
Upload Win32 and x64 artifacts to Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,17 @@ jobs:
       matrix:
         config:
         - {
-            name: "Visual Studio 64-bit",
+            name: "Win32",
+            os: windows-latest,
+            cmake_opts: "-A Win32 \
+              -DALSOFT_BUILD_ROUTER=ON \
+              -DALSOFT_REQUIRE_WINMM=ON \
+              -DALSOFT_REQUIRE_DSOUND=ON \
+              -DALSOFT_REQUIRE_WASAPI=ON",
+            build_type: "Release"
+          }
+        - {
+            name: "Win64",
             os: windows-latest,
             cmake_opts: "-A x64 \
               -DALSOFT_BUILD_ROUTER=ON \
@@ -64,3 +74,10 @@ jobs:
       shell: bash
       run: |
         cmake --build build --config ${{matrix.config.build_type}}
+
+    - name: Upload Archive
+      # Upload package as an artifact of this workflow.
+      uses: actions/upload-artifact@v2
+      with:
+        name: soft_oal-${{matrix.config.name}}
+        path: ${{github.workspace}}/build/${{matrix.config.build_type}}/soft_oal.dll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
     - name: Upload Archive
       # Upload package as an artifact of this workflow.
       uses: actions/upload-artifact@v2
+      if: ${{ matrix.config.os == 'windows-latest' }}
       with:
         name: soft_oal-${{matrix.config.name}}
         path: ${{github.workspace}}/build/${{matrix.config.build_type}}/soft_oal.dll


### PR DESCRIPTION
Provides an alternative Windows binary download location that expires in 3 months (2 months longer than Appveyor)