### PR TITLE
Added missing header file for std::assume_aligned. (C++20)

### DIFF
--- a/common/opthelpers.h
+++ b/common/opthelpers.h
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 #include <utility>
-
+#include <memory>
 
 #ifdef __has_builtin
 #define HAS_BUILTIN __has_builtin


### PR DESCRIPTION
Fix compilation error in Clang using C++20.
Tested on Clang 13.0.0