### PR TITLE
Workaround when using MinGW x86 when compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,7 +472,7 @@ if(CMAKE_SIZEOF_VOID_P MATCHES "4" AND HAVE_SSE2)
             # assumes the stack is suitably aligned. Older Linux code or other
             # OSs don't guarantee this on 32-bit, so externally-callable
             # functions need to ensure an aligned stack.
-            set(EXPORT_DECL "${EXPORT_DECL} __attribute__((force_align_arg_pointer))")
+            set(EXPORT_DECL "${EXPORT_DECL}__attribute__((force_align_arg_pointer))")
         endif()
     endif()
 endif()


### PR DESCRIPTION
This fixes #715. The current version of windres doesn't parse command line arguments correctly when there's a space between them. The part that causes the error is a `-D` directive that defines a macro with two attributes, separated by space. That space is the problem and causes windres to misparse the argument, even if the two attributes are quoted.

The workaround here is to simply remove the space between the two attributes. I can confirm that with this fix, GCC 12 + MinGW 10 x86 is able to successfully build openal-soft.