### PR TITLE
Fix possible C2084 compiler error

### DIFF
--- a/al/eax/api.h
+++ b/al/eax/api.h
@@ -28,7 +28,7 @@ typedef struct _GUID {
     std::uint8_t Data4[8];
 } GUID;
 
-#if !defined _SYS_GUID_OPERATOR_EQ_
+#ifndef _SYS_GUID_OPERATOR_EQ_
 #define _SYS_GUID_OPERATOR_EQ_
 inline bool operator==(const GUID& lhs, const GUID& rhs) noexcept
 { return std::memcmp(&lhs, &rhs, sizeof(GUID)) == 0; }

--- a/al/eax/api.h
+++ b/al/eax/api.h
@@ -28,11 +28,14 @@ typedef struct _GUID {
     std::uint8_t Data4[8];
 } GUID;
 
+#if !defined _SYS_GUID_OPERATOR_EQ_
+#define _SYS_GUID_OPERATOR_EQ_
 inline bool operator==(const GUID& lhs, const GUID& rhs) noexcept
 { return std::memcmp(&lhs, &rhs, sizeof(GUID)) == 0; }
 
 inline bool operator!=(const GUID& lhs, const GUID& rhs) noexcept
 { return !(lhs == rhs); }
+#endif  // _SYS_GUID_OPERATOR_EQ_
 #endif // GUID_DEFINED
 
 


### PR DESCRIPTION
Guiddef.h uses a separate header guard to define the GUID operators, in the current codebase this won't cause any issue, but i got such error while fiddling a bit with the program and including something that ended up including all the various windows headers, that ended up including Guiddef.h, causing the error as by not finding the macro declared, it ended up declaring the inline operators as well.