### PR TITLE
Fix router not loading on Creative's hardware OpenAL

### DIFF
--- a/router/router.cpp
+++ b/router/router.cpp
@@ -189,18 +189,6 @@ static void AddModule(HMODULE module, const WCHAR *name)
     LOAD_PROC(alGenBuffers);
     LOAD_PROC(alDeleteBuffers);
     LOAD_PROC(alIsBuffer);
-    LOAD_PROC(alBufferf);
-    LOAD_PROC(alBuffer3f);
-    LOAD_PROC(alBufferfv);
-    LOAD_PROC(alBufferi);
-    LOAD_PROC(alBuffer3i);
-    LOAD_PROC(alBufferiv);
-    LOAD_PROC(alGetBufferf);
-    LOAD_PROC(alGetBuffer3f);
-    LOAD_PROC(alGetBufferfv);
-    LOAD_PROC(alGetBufferi);
-    LOAD_PROC(alGetBuffer3i);
-    LOAD_PROC(alGetBufferiv);
     LOAD_PROC(alBufferData);
     LOAD_PROC(alDopplerFactor);
     LOAD_PROC(alDopplerVelocity);
@@ -218,6 +206,28 @@ static void AddModule(HMODULE module, const WCHAR *name)
             WARN("Failed to query ALC version for %ls, assuming 1.0\n", name);
             newdrv.ALCVer = MAKE_ALC_VER(1, 0);
         }
+
+#undef LOAD_PROC
+#define LOAD_PROC(x) do {                                                      \
+    newdrv.x = reinterpret_cast<decltype(newdrv.x)>(reinterpret_cast<void*>(   \
+        GetProcAddress(module, #x)));                                          \
+    if(!newdrv.x)                                                              \
+    {                                                                          \
+        WARN("Failed to find optional entry point for %s in %ls\n", #x, name); \
+    }                                                                          \
+} while(0)
+    LOAD_PROC(alBufferf);
+    LOAD_PROC(alBuffer3f);
+    LOAD_PROC(alBufferfv);
+    LOAD_PROC(alBufferi);
+    LOAD_PROC(alBuffer3i);
+    LOAD_PROC(alBufferiv);
+    LOAD_PROC(alGetBufferf);
+    LOAD_PROC(alGetBuffer3f);
+    LOAD_PROC(alGetBufferfv);
+    LOAD_PROC(alGetBufferi);
+    LOAD_PROC(alGetBuffer3i);
+    LOAD_PROC(alGetBufferiv);
 
 #undef LOAD_PROC
 #define LOAD_PROC(x) do {                                                     \


### PR DESCRIPTION
According to the programming guide and the specification, those functions may be used by extensions. However, Creative's hardware OpenAL chose to not implement stub functions for those that they do not use. Currently they use only alBufferi for X-RAM related functions.

Other implementations, such as OpenAL Soft and wrap_oal implement stub functions for those methods therefore they work.

This commit turns those functions optional, just like they were in the old FOSS router. Consumers of the router will receive a nullptr as expected for not implemented methods if they load them using alGetProcAddress, which I believe is the correct way to do so. That is, the context must be current before loading al* functions.