### PR TITLE
Update upload-artifact to remove warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Upload Archive
       # Upload package as an artifact of this workflow.
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1.1
       if: ${{ matrix.config.os == 'windows-latest' }}
       with:
         name: soft_oal-${{matrix.config.name}}


### PR DESCRIPTION
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/upload-artifact

This should fix 2 of the 3 warnings here: https://github.com/kcat/openal-soft/actions/runs/3303596206 
like this https://github.com/ThreeDeeJay/openal-soft/actions/runs/3307517024
by updating to this https://github.com/actions/upload-artifact/releases/tag/v3.1.1 
The other warning is more of a heads up of the macOS runner being updated so it should go away eventually