### PR TITLE
Add GitHub actions workflow to build utils/makemhr on update

### DIFF
--- a/.github/workflows/makemhr.yml
+++ b/.github/workflows/makemhr.yml
@@ -1,0 +1,76 @@
+name: makemhr
+
+on:
+  push:
+    paths:
+      - 'utils/makemhr/**'
+      - '.github/workflows/makemhr.yml'
+
+  workflow_dispatch:
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  Win64:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Get current date
+      run: echo "CurrentDate=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
+
+    - name: Get commit hash
+      run: echo "CommitHash=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
+
+    - name: Clone libmysofa
+      run: git clone https://github.com/hoene/libmysofa.git libmysofa
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.1.3
+
+    - name: Restore libmysofa NuGet packages
+      working-directory: ${{github.workspace}}/libmysofa
+      run: nuget restore ${{github.workspace}}/libmysofa/windows/libmysofa.sln
+
+    - name: Build libmysofa
+      working-directory: ${{github.workspace}}/libmysofa
+      run: msbuild /m /p:Configuration=${{env.BUILD_TYPE}} ${{github.workspace}}/libmysofa/windows/libmysofa.sln
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -D "MYSOFA_LIBRARY=${{github.workspace}}/libmysofa/windows/bin/x64/Release/mysofa.lib" -D "MYSOFA_INCLUDE_DIR=${{github.workspace}}/libmysofa/src/hrtf" -D "ZLIB_LIBRARY=${{github.workspace}}/libmysofa/windows/third-party/zlib-1.2.11/lib/zlib.lib" -D "ZLIB_INCLUDE_DIR=${{github.workspace}}/libmysofa/windows/third-party/zlib-1.2.11/include"
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Make Artifacts folder
+      run: |
+        mkdir "Artifacts"
+        mkdir "Release"
+
+    - name: Collect artifacts
+      run: |
+        copy "build/Release/makemhr.exe" "Artifacts/makemhr.exe"
+        copy "libmysofa/windows/third-party/zlib-1.2.11/bin/zlib.dll" "Artifacts/zlib.dll"
+
+    - name: Upload makemhr artifact
+      uses: actions/upload-artifact@v3.1.1
+      with:
+        name: makemhr
+        path: "Artifacts/"
+
+    - name: Compress artifacts
+      uses: papeloto/action-zip@v1
+      with:
+        files: Artifacts/
+        dest: "Release/makemhr.zip"
+
+    - name: GitHub pre-release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{secrets.GITHUB_TOKEN}}"
+        automatic_release_tag: "makemhr"
+        prerelease: true
+        title: "[${{env.CurrentDate}}] makemhr-${{env.CommitHash}}"
+        files: "Release/makemhr.zip"

--- a/.github/workflows/makemhr.yml
+++ b/.github/workflows/makemhr.yml
@@ -25,7 +25,7 @@ jobs:
       run: echo "CommitHash=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
 
     - name: Clone libmysofa
-      run: git clone https://github.com/hoene/libmysofa.git libmysofa
+      run: git clone --depth 1 --branch v1.3.1 https://github.com/hoene/libmysofa.git libmysofa
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3


### PR DESCRIPTION
This workflow [builds makemhr.exe including dependencies (libmysofa, zlib, etc)](https://github.com/ThreeDeeJay/openal-soft/actions/runs/3457267682/jobs/5770580210) whenever anything under utils/makemhr or the workflow is updated.
It also uploads artifacts and [(pre)releases it with its own tag](https://github.com/ThreeDeeJay/openal-soft/releases/tag/makemhr) for a [permanent, up-to-date download link](https://github.com/ThreeDeeJay/openal-soft/releases/download/makemhr/makemhr.zip).