### PR TITLE
Fix RingBuffer crash in OpenSL backend

### DIFF
--- a/alc/backends/opensl.cpp
+++ b/alc/backends/opensl.cpp
@@ -619,7 +619,7 @@ void OpenSLPlayback::stop()
         } while(SL_RESULT_SUCCESS == result && state.count > 0);
         PRINTERR(result, "bufferQueue->GetState");
 
-        mRing.reset();
+        mRing->reset();
     }
 }
 


### PR DESCRIPTION
This crash happens when you use alcDevicePauseSoft in android and then use alcDeviceResumeSoft
Seems like there should be "->" instead of "."