### PR TITLE
cleanup switch statements with no case label

### DIFF
--- a/al/auxeffectslot.cpp
+++ b/al/auxeffectslot.cpp
@@ -710,12 +710,8 @@ START_API_FUNC
     if(!slot) [[unlikely]]
         return context->setError(AL_INVALID_NAME, "Invalid effect slot ID %u", effectslot);
 
-    switch(param)
-    {
-    default:
-        return context->setError(AL_INVALID_ENUM,
-            "Invalid effect slot integer-vector property 0x%04x", param);
-    }
+    return context->setError(AL_INVALID_ENUM,
+        "Invalid effect slot integer-vector property 0x%04x", param);
 }
 END_API_FUNC
 
@@ -767,12 +763,8 @@ START_API_FUNC
     if(!slot) [[unlikely]]
         return context->setError(AL_INVALID_NAME, "Invalid effect slot ID %u", effectslot);
 
-    switch(param)
-    {
-    default:
-        return context->setError(AL_INVALID_ENUM,
-            "Invalid effect slot float-vector property 0x%04x", param);
-    }
+    return context->setError(AL_INVALID_ENUM,
+        "Invalid effect slot float-vector property 0x%04x", param);
 }
 END_API_FUNC
 
@@ -840,12 +832,7 @@ START_API_FUNC
     if(!slot) [[unlikely]]
         return context->setError(AL_INVALID_NAME, "Invalid effect slot ID %u", effectslot);
 
-    switch(param)
-    {
-    default:
-        context->setError(AL_INVALID_ENUM, "Invalid effect slot integer-vector property 0x%04x",
-            param);
-    }
+    context->setError(AL_INVALID_ENUM, "Invalid effect slot integer-vector property 0x%04x", param);
 }
 END_API_FUNC
 
@@ -890,12 +877,7 @@ START_API_FUNC
     if(!slot) [[unlikely]]
         return context->setError(AL_INVALID_NAME, "Invalid effect slot ID %u", effectslot);
 
-    switch(param)
-    {
-    default:
-        context->setError(AL_INVALID_ENUM, "Invalid effect slot float-vector property 0x%04x",
-            param);
-    }
+    context->setError(AL_INVALID_ENUM, "Invalid effect slot float-vector property 0x%04x", param);
 }
 END_API_FUNC
 

--- a/al/buffer.cpp
+++ b/al/buffer.cpp
@@ -986,11 +986,8 @@ START_API_FUNC
 
     if(LookupBuffer(device, buffer) == nullptr) [[unlikely]]
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer float property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1006,11 +1003,8 @@ START_API_FUNC
 
     if(LookupBuffer(device, buffer) == nullptr) [[unlikely]]
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer 3-float property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1027,11 +1021,8 @@ START_API_FUNC
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
     else if(!values) [[unlikely]]
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer float-vector property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1110,11 +1101,8 @@ START_API_FUNC
 
     if(LookupBuffer(device, buffer) == nullptr) [[unlikely]]
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer 3-integer property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1184,11 +1172,8 @@ START_API_FUNC
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
     else if(!value) [[unlikely]]
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer float property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1205,11 +1190,8 @@ START_API_FUNC
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
     else if(!value1 || !value2 || !value3) [[unlikely]]
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer 3-float property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1233,11 +1215,8 @@ START_API_FUNC
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
     else if(!values) [[unlikely]]
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer float-vector property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1313,11 +1292,8 @@ START_API_FUNC
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
     else if(!value1 || !value2 || !value3) [[unlikely]]
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer 3-integer property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1435,11 +1411,8 @@ START_API_FUNC
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
     else if(!value1 || !value2 || !value3) [[unlikely]]
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer 3-pointer property 0x%04x", param);
-    }
 }
 END_API_FUNC
 
@@ -1463,11 +1436,8 @@ START_API_FUNC
         context->setError(AL_INVALID_NAME, "Invalid buffer ID %u", buffer);
     else if(!values) [[unlikely]]
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid buffer pointer-vector property 0x%04x", param);
-    }
 }
 END_API_FUNC
 

--- a/al/effects/convolution.cpp
+++ b/al/effects/convolution.cpp
@@ -12,72 +12,36 @@ namespace {
 
 void Convolution_setParami(EffectProps* /*props*/, ALenum param, int /*val*/)
 {
-    switch(param)
-    {
-    default:
-        throw effect_exception{AL_INVALID_ENUM, "Invalid null effect integer property 0x%04x",
-            param};
-    }
+    throw effect_exception{AL_INVALID_ENUM, "Invalid null effect integer property 0x%04x", param};
 }
 void Convolution_setParamiv(EffectProps *props, ALenum param, const int *vals)
 {
-    switch(param)
-    {
-    default:
-        Convolution_setParami(props, param, vals[0]);
-    }
+    Convolution_setParami(props, param, vals[0]);
 }
 void Convolution_setParamf(EffectProps* /*props*/, ALenum param, float /*val*/)
 {
-    switch(param)
-    {
-    default:
-        throw effect_exception{AL_INVALID_ENUM, "Invalid null effect float property 0x%04x",
-            param};
-    }
+    throw effect_exception{AL_INVALID_ENUM, "Invalid null effect float property 0x%04x", param};
 }
 void Convolution_setParamfv(EffectProps *props, ALenum param, const float *vals)
 {
-    switch(param)
-    {
-    default:
-        Convolution_setParamf(props, param, vals[0]);
-    }
+    Convolution_setParamf(props, param, vals[0]);
 }
 
 void Convolution_getParami(const EffectProps* /*props*/, ALenum param, int* /*val*/)
 {
-    switch(param)
-    {
-    default:
-        throw effect_exception{AL_INVALID_ENUM, "Invalid null effect integer property 0x%04x",
-            param};
-    }
+    throw effect_exception{AL_INVALID_ENUM, "Invalid null effect integer property 0x%04x", param};
 }
 void Convolution_getParamiv(const EffectProps *props, ALenum param, int *vals)
 {
-    switch(param)
-    {
-    default:
-        Convolution_getParami(props, param, vals);
-    }
+    Convolution_getParami(props, param, vals);
 }
 void Convolution_getParamf(const EffectProps* /*props*/, ALenum param, float* /*val*/)
 {
-    switch(param)
-    {
-    default:
-        throw effect_exception{AL_INVALID_ENUM, "Invalid null effect float property 0x%04x",
-            param};
-    }
+    throw effect_exception{AL_INVALID_ENUM, "Invalid null effect float property 0x%04x", param};
 }
 void Convolution_getParamfv(const EffectProps *props, ALenum param, float *vals)
 {
-    switch(param)
-    {
-    default:
-        Convolution_getParamf(props, param, vals);
-    }
+    Convolution_getParamf(props, param, vals);
 }
 
 EffectProps genDefaultProps() noexcept

--- a/al/effects/null.cpp
+++ b/al/effects/null.cpp
@@ -16,72 +16,36 @@ namespace {
 
 void Null_setParami(EffectProps* /*props*/, ALenum param, int /*val*/)
 {
-    switch(param)
-    {
-    default:
-        throw effect_exception{AL_INVALID_ENUM, "Invalid null effect integer property 0x%04x",
-            param};
-    }
+    throw effect_exception{AL_INVALID_ENUM, "Invalid null effect integer property 0x%04x", param};
 }
 void Null_setParamiv(EffectProps *props, ALenum param, const int *vals)
 {
-    switch(param)
-    {
-    default:
-        Null_setParami(props, param, vals[0]);
-    }
+    Null_setParami(props, param, vals[0]);
 }
 void Null_setParamf(EffectProps* /*props*/, ALenum param, float /*val*/)
 {
-    switch(param)
-    {
-    default:
-        throw effect_exception{AL_INVALID_ENUM, "Invalid null effect float property 0x%04x",
-            param};
-    }
+    throw effect_exception{AL_INVALID_ENUM, "Invalid null effect float property 0x%04x", param};
 }
 void Null_setParamfv(EffectProps *props, ALenum param, const float *vals)
 {
-    switch(param)
-    {
-    default:
-        Null_setParamf(props, param, vals[0]);
-    }
+    Null_setParamf(props, param, vals[0]);
 }
 
 void Null_getParami(const EffectProps* /*props*/, ALenum param, int* /*val*/)
 {
-    switch(param)
-    {
-    default:
-        throw effect_exception{AL_INVALID_ENUM, "Invalid null effect integer property 0x%04x",
-            param};
-    }
+    throw effect_exception{AL_INVALID_ENUM, "Invalid null effect integer property 0x%04x", param};
 }
 void Null_getParamiv(const EffectProps *props, ALenum param, int *vals)
 {
-    switch(param)
-    {
-    default:
-        Null_getParami(props, param, vals);
-    }
+    Null_getParami(props, param, vals);
 }
 void Null_getParamf(const EffectProps* /*props*/, ALenum param, float* /*val*/)
 {
-    switch(param)
-    {
-    default:
-        throw effect_exception{AL_INVALID_ENUM, "Invalid null effect float property 0x%04x",
-            param};
-    }
+    throw effect_exception{AL_INVALID_ENUM, "Invalid null effect float property 0x%04x", param};
 }
 void Null_getParamfv(const EffectProps *props, ALenum param, float *vals)
 {
-    switch(param)
-    {
-    default:
-        Null_getParamf(props, param, vals);
-    }
+    Null_getParamf(props, param, vals);
 }
 
 EffectProps genDefaultProps() noexcept

--- a/al/listener.cpp
+++ b/al/listener.cpp
@@ -198,11 +198,7 @@ START_API_FUNC
     if(!context) [[unlikely]] return;
 
     std::lock_guard<std::mutex> _{context->mPropLock};
-    switch(param)
-    {
-    default:
-        context->setError(AL_INVALID_ENUM, "Invalid listener integer property");
-    }
+    context->setError(AL_INVALID_ENUM, "Invalid listener integer property");
 }
 END_API_FUNC
 
@@ -222,11 +218,7 @@ START_API_FUNC
     if(!context) [[unlikely]] return;
 
     std::lock_guard<std::mutex> _{context->mPropLock};
-    switch(param)
-    {
-    default:
-        context->setError(AL_INVALID_ENUM, "Invalid listener 3-integer property");
-    }
+    context->setError(AL_INVALID_ENUM, "Invalid listener 3-integer property");
 }
 END_API_FUNC
 
@@ -262,11 +254,8 @@ START_API_FUNC
     std::lock_guard<std::mutex> _{context->mPropLock};
     if(!values) [[unlikely]]
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid listener integer-vector property");
-    }
 }
 END_API_FUNC
 
@@ -378,11 +367,8 @@ START_API_FUNC
     std::lock_guard<std::mutex> _{context->mPropLock};
     if(!value)
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(param)
-    {
-    default:
+    else
         context->setError(AL_INVALID_ENUM, "Invalid listener integer property");
-    }
 }
 END_API_FUNC
 

--- a/al/state.cpp
+++ b/al/state.cpp
@@ -579,11 +579,8 @@ START_API_FUNC
 
     if(!values)
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(pname)
-    {
-    default:
+    else
         context->setError(AL_INVALID_VALUE, "Invalid boolean-vector property 0x%04x", pname);
-    }
 }
 END_API_FUNC
 
@@ -612,11 +609,8 @@ START_API_FUNC
 
     if(!values)
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(pname)
-    {
-    default:
+    else
         context->setError(AL_INVALID_VALUE, "Invalid double-vector property 0x%04x", pname);
-    }
 }
 END_API_FUNC
 
@@ -645,11 +639,8 @@ START_API_FUNC
 
     if(!values)
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(pname)
-    {
-    default:
+    else
         context->setError(AL_INVALID_VALUE, "Invalid float-vector property 0x%04x", pname);
-    }
 }
 END_API_FUNC
 
@@ -678,11 +669,8 @@ START_API_FUNC
 
     if(!values)
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(pname)
-    {
-    default:
+    else
         context->setError(AL_INVALID_VALUE, "Invalid integer-vector property 0x%04x", pname);
-    }
 }
 END_API_FUNC
 
@@ -711,11 +699,8 @@ START_API_FUNC
 
     if(!values)
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(pname)
-    {
-    default:
+    else
         context->setError(AL_INVALID_VALUE, "Invalid integer64-vector property 0x%04x", pname);
-    }
 }
 END_API_FUNC
 
@@ -738,11 +723,8 @@ START_API_FUNC
 
     if(!values)
         context->setError(AL_INVALID_VALUE, "NULL pointer");
-    else switch(pname)
-    {
-    default:
+    else
         context->setError(AL_INVALID_VALUE, "Invalid pointer-vector property 0x%04x", pname);
-    }
 }
 END_API_FUNC
 


### PR DESCRIPTION
This fixes warning C4065 on msvc