### PR TITLE
Add reference to Binaural Audio database

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ users and sysadmins to control information provided to applications, as well
 as application-agnostic behavior of the library. See alsoftrc.sample for
 available settings.
 
+Compatibility
+-------------
+
+For a list of games and applications tested/potentially compatible with OpenAL Soft as well as demos, guides and other info, check out the Binaural Audio database: https://airtable.com/shryB7ft0Cle17cLA
 
 Acknowledgements
 ----------------


### PR DESCRIPTION
There's an ongoing effort to [document the best known configurations](https://airtable.com/shrtTsUtiAJQ7wFGI) to get 3D/spatial audio and virtual surround in games/apps so I figured it'd be helpful to have the [filtered view that only shows relevant (OpenAL Soft) configurations](https://airtable.com/shryB7ft0Cle17cLA) in the ReadMe so people can find it more easily.