### PR TITLE
Fixes for Darwin: fallback for systems without libdispatch; fix for undefined types from inttypes.h

### DIFF
--- a/common/threads.cpp
+++ b/common/threads.cpp
@@ -128,7 +128,8 @@ void althrd_setname(const char *name [[maybe_unused]])
 #endif
 }
 
-#ifdef __APPLE__
+/* Do not try using libdispatch on systems where it is absent. */
+#if defined(__APPLE__) && ((MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__ppc__))
 
 namespace al {
 

--- a/common/threads.h
+++ b/common/threads.h
@@ -15,7 +15,12 @@
 #endif
 
 #if defined(__APPLE__)
+#include <AvailabilityMacros.h>
+#if (MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__ppc__)
 #include <dispatch/dispatch.h>
+#else
+#include <semaphore.h> /* Fallback option for Apple without a working libdispatch */
+#endif
 #elif !defined(_WIN32)
 #include <semaphore.h>
 #endif
@@ -27,7 +32,7 @@ namespace al {
 class semaphore {
 #ifdef _WIN32
     using native_type = void*;
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && ((MAC_OS_X_VERSION_MIN_REQUIRED > 1050) && !defined(__ppc__))
     using native_type = dispatch_semaphore_t;
 #else
     using native_type = sem_t;


### PR DESCRIPTION
This PR addresses the build on macOS < 10.7 and PowerPC, which are currently broken for two reasons:
1. Unconditionally using `libdispatch`.
2. Missing define of `__STDC_FORMAT_MACROS`.

With these fixed, `openal-soft` builds successfully.