### PR TITLE
Add ios ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,18 @@ jobs:
             build_type: "Release"
           }
         - {
+            name: "iOS-Release",
+            os: macos-latest,
+            cmake_opts: "-GXcode \
+            -DCMAKE_SYSTEM_NAME=iOS \
+            -DALSOFT_REQUIRE_COREAUDIO=ON \
+            -DALSOFT_UTILS=OFF \
+            -DALSOFT_EXAMPLES=OFF \
+            -DALSOFT_INSTALL=OFF \
+            \"-DCMAKE_OSX_ARCHITECTURES=arm64\"",
+            build_type: "Release"
+          }
+        - {
             name: "Linux-Release",
             os: ubuntu-latest,
             cmake_opts: "-DALSOFT_REQUIRE_RTKIT=ON \


### PR DESCRIPTION
@kcat  The latest code has compile error for ios build,

```txt
/Users/runner/work/openal-soft/openal-soft/alc/backends/coreaudio.cpp:44:10: fatal error: 'IOKit/audio/IOAudioTypes.h' file not found
```

refer to: https://github.com/halx99/openal-soft/actions/runs/5133473000/jobs/9236097000#step:5:385