### PR TITLE
Fix linker error with undefined symbol '=' on MSVC

### DIFF
--- a/alc/backends/dsound.cpp
+++ b/alc/backends/dsound.cpp
@@ -331,7 +331,7 @@ void DSoundPlayback::open(const char *name)
             hr = CLSIDFromString(utf8_to_wstr(name).c_str(), &id);
             if(SUCCEEDED(hr))
                 iter = std::find_if(PlaybackDevices.cbegin(), PlaybackDevices.cend(),
-                    [&id](const DevMap &entry) -> bool { return entry.guid == id; });
+                    [&id](const DevMap &entry) -> bool { return !!IsEqualGUID(entry.guid, id); });
             if(iter == PlaybackDevices.cend())
                 throw al::backend_exception{al::backend_error::NoDevice,
                     "Device name \"%s\" not found", name};
@@ -606,7 +606,7 @@ void DSoundCapture::open(const char *name)
             hr = CLSIDFromString(utf8_to_wstr(name).c_str(), &id);
             if(SUCCEEDED(hr))
                 iter = std::find_if(CaptureDevices.cbegin(), CaptureDevices.cend(),
-                    [&id](const DevMap &entry) -> bool { return entry.guid == id; });
+                    [&id](const DevMap &entry) -> bool { return !!IsEqualGUID(entry.guid, id); });
             if(iter == CaptureDevices.cend())
                 throw al::backend_exception{al::backend_error::NoDevice,
                     "Device name \"%s\" not found", name};

--- a/alc/backends/wasapi.cpp
+++ b/alc/backends/wasapi.cpp
@@ -415,21 +415,21 @@ struct DeviceHelper final : private IMMNotificationClient
         // interface pointer, the reference count becomes two. The client must call Release twice on the interface
         // pointer to drop all of its references to the object.
 #if defined(ALSOFT_UWP)
-        if(IId == __uuidof(IActivateAudioInterfaceCompletionHandler))
+        if(IsEqualIID(IId, __uuidof(IActivateAudioInterfaceCompletionHandler)))
         {
             *UnknownPtrPtr = static_cast<IActivateAudioInterfaceCompletionHandler*>(this);
             AddRef();
             return S_OK;
         }
 #else
-        if(IId == __uuidof(IMMNotificationClient))
+        if(IsEqualIID(IId, __uuidof(IMMNotificationClient)))
         {
             *UnknownPtrPtr = static_cast<IMMNotificationClient*>(this);
             AddRef();
             return S_OK;
         }
 #endif
-        else if(IId == __uuidof(IAgileObject) || IId == __uuidof(IUnknown))
+        else if(IsEqualIID(IId, __uuidof(IAgileObject)) || IsEqualIID(IId, __uuidof(IUnknown)))
         {
             *UnknownPtrPtr = static_cast<IUnknown*>(this);
             AddRef();

--- a/alc/context.h
+++ b/alc/context.h
@@ -24,6 +24,8 @@
 #include "intrusive_ptr.h"
 
 #ifdef ALSOFT_EAX
+#include <guiddef.h>
+
 #include "al/eax/call.h"
 #include "al/eax/exception.h"
 #include "al/eax/fx_slot_index.h"
@@ -307,11 +309,11 @@ private:
     struct Eax4PrimaryFxSlotIdValidator {
         void operator()(const GUID& guidPrimaryFXSlotID) const
         {
-            if(guidPrimaryFXSlotID != EAX_NULL_GUID &&
-                guidPrimaryFXSlotID != EAXPROPERTYID_EAX40_FXSlot0 &&
-                guidPrimaryFXSlotID != EAXPROPERTYID_EAX40_FXSlot1 &&
-                guidPrimaryFXSlotID != EAXPROPERTYID_EAX40_FXSlot2 &&
-                guidPrimaryFXSlotID != EAXPROPERTYID_EAX40_FXSlot3)
+            if(!IsEqualGUID(guidPrimaryFXSlotID, EAX_NULL_GUID) &&
+                !IsEqualGUID(guidPrimaryFXSlotID, EAXPROPERTYID_EAX40_FXSlot0) &&
+                !IsEqualGUID(guidPrimaryFXSlotID, EAXPROPERTYID_EAX40_FXSlot1) &&
+                !IsEqualGUID(guidPrimaryFXSlotID, EAXPROPERTYID_EAX40_FXSlot2) &&
+                !IsEqualGUID(guidPrimaryFXSlotID, EAXPROPERTYID_EAX40_FXSlot3))
             {
                 eax_fail_unknown_primary_fx_slot_id();
             }
@@ -364,11 +366,11 @@ private:
     struct Eax5PrimaryFxSlotIdValidator {
         void operator()(const GUID& guidPrimaryFXSlotID) const
         {
-            if(guidPrimaryFXSlotID != EAX_NULL_GUID &&
-                guidPrimaryFXSlotID != EAXPROPERTYID_EAX50_FXSlot0 &&
-                guidPrimaryFXSlotID != EAXPROPERTYID_EAX50_FXSlot1 &&
-                guidPrimaryFXSlotID != EAXPROPERTYID_EAX50_FXSlot2 &&
-                guidPrimaryFXSlotID != EAXPROPERTYID_EAX50_FXSlot3)
+            if(!IsEqualGUID(guidPrimaryFXSlotID, EAX_NULL_GUID) &&
+                !IsEqualGUID(guidPrimaryFXSlotID, EAXPROPERTYID_EAX50_FXSlot0) &&
+                !IsEqualGUID(guidPrimaryFXSlotID, EAXPROPERTYID_EAX50_FXSlot1) &&
+                !IsEqualGUID(guidPrimaryFXSlotID, EAXPROPERTYID_EAX50_FXSlot2) &&
+                !IsEqualGUID(guidPrimaryFXSlotID, EAXPROPERTYID_EAX50_FXSlot3))
             {
                 eax_fail_unknown_primary_fx_slot_id();
             }


### PR DESCRIPTION
Reason for such symbol to ever exist is `operator==` for GUID/IID (see guiddef.h)
CMake exports such symbol into exports.def where LINK reads it and (obviously) does not found it, which cause linker error
Such error only happens with Debug build, because `operator==` and `operator!=` isn't inlined
Replacing every occurrence of `operator==` (AND `operator!=` because it uses `operator==` internally) with `IsEqualGUID` or `IsEqualIID` fixes this issue

For some unknown to me reason using `operator==` in `AL` is fine and doesn't cause such behaviour to happen (i believe this happens because it's exported manually instead of automatic CMake export)