### PR TITLE
xcode14.3 ios deploy target 11.0 compile error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
             -DALSOFT_EXAMPLES=OFF \
             -DALSOFT_TESTS=OFF \
             -DALSOFT_INSTALL=OFF \
+            \"-dCMAKE_OSX_DEPLOYMENT_TARGET=11.0\" \
             \"-DCMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET=11.0\" \
             \"-DCMAKE_OSX_ARCHITECTURES=arm64\"",
             build_type: "Release"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
             -DALSOFT_EXAMPLES=OFF \
             -DALSOFT_TESTS=OFF \
             -DALSOFT_INSTALL=OFF \
+            \"-DCMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET=11.0\" \
             \"-DCMAKE_OSX_ARCHITECTURES=arm64\"",
             build_type: "Release"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             -DALSOFT_EXAMPLES=OFF \
             -DALSOFT_TESTS=OFF \
             -DALSOFT_INSTALL=OFF \
-            \"-dCMAKE_OSX_DEPLOYMENT_TARGET=11.0\" \
+            \"-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0\" \
             \"-DCMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET=11.0\" \
             \"-DCMAKE_OSX_ARCHITECTURES=arm64\"",
             build_type: "Release"


### PR DESCRIPTION
Latest code can't compile ios when deployment target < 12.0, due to `std::get` for `std::variant` not supported, previous release works well.

If you don't want support ios deployment target < 12.0, just ignore this patch