### PR TITLE
Return noErr from DeviceListenerProc

### DIFF
--- a/alc/backends/coreaudio.cpp
+++ b/alc/backends/coreaudio.cpp
@@ -309,6 +309,7 @@ struct DeviceHelper {
                 break;
             }
         }
+        return noErr;
     }
 };
 


### PR DESCRIPTION
The library currently fails to compile under macos with clang with `-Werror=return-type`. This patch fixes the issue.