### PR TITLE
Fix CMake deprecation warning in OpenAL config

### DIFF
--- a/OpenALConfig.cmake.in
+++ b/OpenALConfig.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.18)
 
 include("${CMAKE_CURRENT_LIST_DIR}/OpenALTargets.cmake")
 


### PR DESCRIPTION
Fixes the following warning with CMake 3.27:

```
CMake Deprecation Warning at /lib/cmake/OpenAL/OpenALConfig.cmake:1 (cmake_minimum_required):
   Compatibility with CMake < 3.5 will be removed from a future version of
   CMake.
 
   Update the VERSION argument <min> value or use a ...<max> suffix to tell
   CMake that the project does not need compatibility with older versions.
 Call Stack (most recent call first):
   vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
   CMakeLists.txt:75 (find_package)
``