### PR TITLE
Add query fonction in ALC_SOFT_system_events unreleased extension

### DIFF
--- a/alc/alc.cpp
+++ b/alc/alc.cpp
@@ -3482,7 +3482,7 @@ FORCE_ALIGN ALCenum ALC_APIENTRY alcEventIsSupportedSOFT(ALCenum eventType, ALCe
     {
         WARN("Invalid event type: 0x%04x\n", eventType);
         alcSetError(nullptr, ALC_INVALID_ENUM);
-        return ALC_EVENT_NOT_SUPPORTED;
+        return ALC_EVENT_NOT_SUPPORTED_SOFT;
     }
     switch(deviceType)
     {
@@ -3490,7 +3490,7 @@ FORCE_ALIGN ALCenum ALC_APIENTRY alcEventIsSupportedSOFT(ALCenum eventType, ALCe
         {
             if(!PlaybackFactory)
             {
-                return ALC_EVENT_NOT_SUPPORTED;
+                return ALC_EVENT_NOT_SUPPORTED_SOFT;
             }
 
             auto supported = PlaybackFactory->queryEventSupport(*etype, BackendType::Playback);
@@ -3500,12 +3500,12 @@ FORCE_ALIGN ALCenum ALC_APIENTRY alcEventIsSupportedSOFT(ALCenum eventType, ALCe
         {
             if(!CaptureFactory)
             {
-                return ALC_EVENT_NOT_SUPPORTED;
+                return ALC_EVENT_NOT_SUPPORTED_SOFT;
             }
 
             auto supported = CaptureFactory->queryEventSupport(*etype, BackendType::Capture);
             return al::to_underlying(supported);
         }
     }
-    return ALC_EVENT_NOT_SUPPORTED;
+    return ALC_EVENT_NOT_SUPPORTED_SOFT;
 }

--- a/alc/backends/base.h
+++ b/alc/backends/base.h
@@ -11,6 +11,7 @@
 
 #include "core/device.h"
 #include "core/except.h"
+#include "alc/events.h"
 
 
 using uint = unsigned int;
@@ -78,6 +79,10 @@ struct BackendFactory {
     virtual bool init() = 0;
 
     virtual bool querySupport(BackendType type) = 0;
+
+    virtual alc::EventSupport queryEventSupport(alc::EventType eventType, BackendType type) {
+        return alc::EventSupport::NoSupport;
+    }
 
     virtual std::string probe(BackendType type) = 0;
 

--- a/alc/backends/coreaudio.cpp
+++ b/alc/backends/coreaudio.cpp
@@ -39,7 +39,6 @@
 #include "core/device.h"
 #include "core/logging.h"
 #include "ringbuffer.h"
-#include "alc/events.h"
 
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>
@@ -1012,4 +1011,14 @@ BackendPtr CoreAudioBackendFactory::createBackend(DeviceBase *device, BackendTyp
     if(type == BackendType::Capture)
         return BackendPtr{new CoreAudioCapture{device}};
     return nullptr;
+}
+
+alc::EventSupport CoreAudioBackendFactory::queryEventSupport(alc::EventType eventType, BackendType type)
+{
+    switch(eventType) {
+        case alc::EventType::DefaultDeviceChanged: {
+            return alc::EventSupport::FullSupport;
+        }
+    }
+    return alc::EventSupport::NoSupport;
 }

--- a/alc/backends/coreaudio.h
+++ b/alc/backends/coreaudio.h
@@ -9,6 +9,8 @@ public:
 
     bool querySupport(BackendType type) override;
 
+    alc::EventSupport queryEventSupport(alc::EventType eventType, BackendType type) override;
+
     std::string probe(BackendType type) override;
 
     BackendPtr createBackend(DeviceBase *device, BackendType type) override;

--- a/alc/backends/pipewire.cpp
+++ b/alc/backends/pipewire.cpp
@@ -40,7 +40,6 @@
 
 #include "albit.h"
 #include "alc/alconfig.h"
-#include "alc/events.h"
 #include "almalloc.h"
 #include "alnumeric.h"
 #include "alspan.h"
@@ -2265,4 +2264,20 @@ BackendFactory &PipeWireBackendFactory::getFactory()
 {
     static PipeWireBackendFactory factory{};
     return factory;
+}
+
+alc::EventSupport PipeWireBackendFactory::queryEventSupport(alc::EventType eventType, BackendType type)
+{
+    switch(eventType) {
+        case alc::EventType::DefaultDeviceChanged: {
+            return alc::EventSupport::FullSupport;
+        }
+        case alc::EventType::DeviceAdded: {
+            return alc::EventSupport::FullSupport;
+        }
+        case alc::EventType::DeviceRemoved: {
+            return alc::EventSupport::FullSupport;
+        }
+    }
+    return alc::EventSupport::NoSupport;
 }

--- a/alc/backends/pipewire.h
+++ b/alc/backends/pipewire.h
@@ -13,6 +13,8 @@ public:
 
     bool querySupport(BackendType type) override;
 
+    alc::EventSupport queryEventSupport(alc::EventType eventType, BackendType type) override;
+
     std::string probe(BackendType type) override;
 
     BackendPtr createBackend(DeviceBase *device, BackendType type) override;

--- a/alc/backends/pulseaudio.cpp
+++ b/alc/backends/pulseaudio.cpp
@@ -41,7 +41,6 @@
 
 #include "albit.h"
 #include "alc/alconfig.h"
-#include "alc/events.h"
 #include "almalloc.h"
 #include "alnumeric.h"
 #include "alspan.h"
@@ -1490,4 +1489,17 @@ BackendFactory &PulseBackendFactory::getFactory()
 {
     static PulseBackendFactory factory{};
     return factory;
+}
+
+alc::EventSupport PulseBackendFactory::queryEventSupport(alc::EventType eventType, BackendType type)
+{
+    switch(eventType) {
+        case alc::EventType::DeviceAdded: {
+            return alc::EventSupport::FullSupport;
+        }
+        case alc::EventType::DeviceRemoved: {
+            return alc::EventSupport::FullSupport;
+        }
+    }
+    return alc::EventSupport::NoSupport;
 }

--- a/alc/backends/pulseaudio.h
+++ b/alc/backends/pulseaudio.h
@@ -9,6 +9,8 @@ public:
 
     bool querySupport(BackendType type) override;
 
+    alc::EventSupport queryEventSupport(alc::EventType eventType, BackendType type) override;
+
     std::string probe(BackendType type) override;
 
     BackendPtr createBackend(DeviceBase *device, BackendType type) override;

--- a/alc/backends/wasapi.cpp
+++ b/alc/backends/wasapi.cpp
@@ -60,7 +60,6 @@
 
 #include "albit.h"
 #include "alc/alconfig.h"
-#include "alc/events.h"
 #include "alnumeric.h"
 #include "alspan.h"
 #include "althrd_setname.h"
@@ -2740,4 +2739,20 @@ BackendFactory &WasapiBackendFactory::getFactory()
 {
     static WasapiBackendFactory factory{};
     return factory;
+}
+
+alc::EventSupport WasapiBackendFactory::queryEventSupport(alc::EventType eventType, BackendType type)
+{
+    switch(eventType) {
+        case alc::EventType::DefaultDeviceChanged: {
+            return alc::EventSupport::FullSupport;
+        }
+        case alc::EventType::DeviceAdded: {
+            return alc::EventSupport::FullSupport;
+        }
+        case alc::EventType::DeviceRemoved: {
+            return alc::EventSupport::FullSupport;
+        }
+    }
+    return alc::EventSupport::NoSupport;
 }

--- a/alc/backends/wasapi.h
+++ b/alc/backends/wasapi.h
@@ -9,6 +9,8 @@ public:
 
     bool querySupport(BackendType type) override;
 
+    alc::EventSupport queryEventSupport(alc::EventType eventType, BackendType type) override;
+
     std::string probe(BackendType type) override;
 
     BackendPtr createBackend(DeviceBase *device, BackendType type) override;

--- a/alc/events.cpp
+++ b/alc/events.cpp
@@ -3,25 +3,12 @@
 
 #include "events.h"
 
-#include <optional>
-
 #include "alspan.h"
 #include "core/logging.h"
 #include "device.h"
 
 
 namespace {
-
-std::optional<alc::EventType> GetEventType(ALCenum type)
-{
-    switch(type)
-    {
-    case ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT: return alc::EventType::DefaultDeviceChanged;
-    case ALC_EVENT_TYPE_DEVICE_ADDED_SOFT: return alc::EventType::DeviceAdded;
-    case ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT: return alc::EventType::DeviceRemoved;
-    }
-    return std::nullopt;
-}
 
 ALCenum EnumFromEventType(const alc::EventType type)
 {
@@ -38,6 +25,17 @@ ALCenum EnumFromEventType(const alc::EventType type)
 } // namespace
 
 namespace alc {
+
+std::optional<alc::EventType> GetEventType(ALCenum type)
+{
+    switch(type)
+    {
+    case ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT: return alc::EventType::DefaultDeviceChanged;
+    case ALC_EVENT_TYPE_DEVICE_ADDED_SOFT: return alc::EventType::DeviceAdded;
+    case ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT: return alc::EventType::DeviceRemoved;
+    }
+    return std::nullopt;
+}
 
 void Event(EventType eventType, DeviceType deviceType, ALCdevice *device, std::string_view message) noexcept
 {
@@ -73,7 +71,7 @@ FORCE_ALIGN ALCboolean ALC_APIENTRY alcEventControlSOFT(ALCsizei count, const AL
     alc::EventBitSet eventSet{0};
     for(ALCenum type : al::span{events, static_cast<ALCuint>(count)})
     {
-        auto etype = GetEventType(type);
+        auto etype = alc::GetEventType(type);
         if(!etype)
         {
             WARN("Invalid event type: 0x%04x\n", type);

--- a/alc/events.h
+++ b/alc/events.h
@@ -24,7 +24,6 @@ std::optional<alc::EventType> GetEventType(ALCenum type);
 
 enum class EventSupport : ALCenum {
     FullSupport = ALC_EVENT_SUPPORTED_SOFT,
-    PartialSupport = ALC_EVENT_PARTIALLY_SUPPORTED_SOFT,
     NoSupport = ALC_EVENT_NOT_SUPPORTED_SOFT,
 };
 

--- a/alc/events.h
+++ b/alc/events.h
@@ -23,9 +23,9 @@ enum class EventType : uint8_t {
 std::optional<alc::EventType> GetEventType(ALCenum type);
 
 enum class EventSupport : ALCenum {
-    FullSupport = ALC_EVENT_SUPPORTED,
-    PartialSupport = ALC_EVENT_PARTIALLY_SUPPORTED,
-    NoSupport = ALC_EVENT_NOT_SUPPORTED,
+    FullSupport = ALC_EVENT_SUPPORTED_SOFT,
+    PartialSupport = ALC_EVENT_PARTIALLY_SUPPORTED_SOFT,
+    NoSupport = ALC_EVENT_NOT_SUPPORTED_SOFT,
 };
 
 enum class DeviceType : ALCenum {

--- a/alc/events.h
+++ b/alc/events.h
@@ -6,6 +6,7 @@
 
 #include <bitset>
 #include <mutex>
+#include <optional>
 #include <string_view>
 
 
@@ -17,6 +18,14 @@ enum class EventType : uint8_t {
     DeviceRemoved,
 
     Count
+};
+
+std::optional<alc::EventType> GetEventType(ALCenum type);
+
+enum class EventSupport : ALCenum {
+    FullSupport = ALC_EVENT_SUPPORTED,
+    PartialSupport = ALC_EVENT_PARTIALLY_SUPPORTED,
+    NoSupport = ALC_EVENT_NOT_SUPPORTED,
 };
 
 enum class DeviceType : ALCenum {

--- a/alc/export_list.h
+++ b/alc/export_list.h
@@ -56,6 +56,7 @@ inline const FuncExport alcFunctions[]{
 
     DECL(alcReopenDeviceSOFT),
 
+    DECL(alcEventIsSupportedSOFT),
     DECL(alcEventControlSOFT),
     DECL(alcEventCallbackSOFT),
 

--- a/include/AL/alext.h
+++ b/include/AL/alext.h
@@ -715,14 +715,14 @@ void AL_APIENTRY alGetObjectLabelEXT(ALenum identifier, ALuint name, ALsizei buf
 
 #ifndef ALC_SOFT_system_events
 #define ALC_SOFT_system_events
-#define ALC_PLAYBACK_DEVICE_SOFT                   0x19D4
-#define ALC_CAPTURE_DEVICE_SOFT                    0x19D5
+#define ALC_PLAYBACK_DEVICE_SOFT                 0x19D4
+#define ALC_CAPTURE_DEVICE_SOFT                  0x19D5
 #define ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT 0x19D6
-#define ALC_EVENT_TYPE_DEVICE_ADDED_SOFT           0x19D7
-#define ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT         0x19D8
-#define ALC_EVENT_SUPPORTED                        0x19D9
-#define ALC_EVENT_PARTIALLY_SUPPORTED              0x19DA
-#define ALC_EVENT_NOT_SUPPORTED                    0x19DB
+#define ALC_EVENT_TYPE_DEVICE_ADDED_SOFT         0x19D7
+#define ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT       0x19D8
+#define ALC_EVENT_SUPPORTED_SOFT                 0x19D9
+#define ALC_EVENT_PARTIALLY_SUPPORTED_SOFT       0x19DA
+#define ALC_EVENT_NOT_SUPPORTED_SOFT             0x19DB
 typedef void (ALC_APIENTRY*ALCEVENTPROCTYPESOFT)(ALCenum eventType, ALCenum deviceType,
     ALCdevice *device, ALCsizei length, const ALCchar *message, void *userParam) ALC_API_NOEXCEPT17;
 typedef ALCenum (ALC_APIENTRY*LPALCEVENTISSUPPORTEDSOFT)(ALCenum eventType, ALCenum deviceType) ALC_API_NOEXCEPT17;

--- a/include/AL/alext.h
+++ b/include/AL/alext.h
@@ -721,8 +721,7 @@ void AL_APIENTRY alGetObjectLabelEXT(ALenum identifier, ALuint name, ALsizei buf
 #define ALC_EVENT_TYPE_DEVICE_ADDED_SOFT         0x19D7
 #define ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT       0x19D8
 #define ALC_EVENT_SUPPORTED_SOFT                 0x19D9
-#define ALC_EVENT_PARTIALLY_SUPPORTED_SOFT       0x19DA
-#define ALC_EVENT_NOT_SUPPORTED_SOFT             0x19DB
+#define ALC_EVENT_NOT_SUPPORTED_SOFT             0x19DA
 typedef void (ALC_APIENTRY*ALCEVENTPROCTYPESOFT)(ALCenum eventType, ALCenum deviceType,
     ALCdevice *device, ALCsizei length, const ALCchar *message, void *userParam) ALC_API_NOEXCEPT17;
 typedef ALCenum (ALC_APIENTRY*LPALCEVENTISSUPPORTEDSOFT)(ALCenum eventType, ALCenum deviceType) ALC_API_NOEXCEPT17;

--- a/include/AL/alext.h
+++ b/include/AL/alext.h
@@ -715,16 +715,21 @@ void AL_APIENTRY alGetObjectLabelEXT(ALenum identifier, ALuint name, ALsizei buf
 
 #ifndef ALC_SOFT_system_events
 #define ALC_SOFT_system_events
-#define ALC_PLAYBACK_DEVICE_SOFT                 0x19D4
-#define ALC_CAPTURE_DEVICE_SOFT                  0x19D5
+#define ALC_PLAYBACK_DEVICE_SOFT                   0x19D4
+#define ALC_CAPTURE_DEVICE_SOFT                    0x19D5
 #define ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT 0x19D6
-#define ALC_EVENT_TYPE_DEVICE_ADDED_SOFT         0x19D7
-#define ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT       0x19D8
+#define ALC_EVENT_TYPE_DEVICE_ADDED_SOFT           0x19D7
+#define ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT         0x19D8
+#define ALC_EVENT_SUPPORTED                        0x19D9
+#define ALC_EVENT_PARTIALLY_SUPPORTED              0x19DA
+#define ALC_EVENT_NOT_SUPPORTED                    0x19DB
 typedef void (ALC_APIENTRY*ALCEVENTPROCTYPESOFT)(ALCenum eventType, ALCenum deviceType,
     ALCdevice *device, ALCsizei length, const ALCchar *message, void *userParam) ALC_API_NOEXCEPT17;
+typedef ALCenum (ALC_APIENTRY*LPALCEVENTISSUPPORTEDSOFT)(ALCenum eventType, ALCenum deviceType) ALC_API_NOEXCEPT17;
 typedef ALCboolean (ALC_APIENTRY*LPALCEVENTCONTROLSOFT)(ALCsizei count, const ALCenum *events, ALCboolean enable) ALC_API_NOEXCEPT17;
 typedef void (ALC_APIENTRY*LPALCEVENTCALLBACKSOFT)(ALCEVENTPROCTYPESOFT callback, void *userParam) ALC_API_NOEXCEPT17;
 #ifdef AL_ALEXT_PROTOTYPES
+ALCenum ALC_APIENTRY alcEventIsSupportedSOFT(ALCenum eventType, ALCenum deviceType) ALC_API_NOEXCEPT;
 ALCboolean ALC_APIENTRY alcEventControlSOFT(ALCsizei count, const ALCenum *events, ALCboolean enable) ALC_API_NOEXCEPT;
 void ALC_APIENTRY alcEventCallbackSOFT(ALCEVENTPROCTYPESOFT callback, void *userParam) ALC_API_NOEXCEPT;
 #endif

--- a/utils/openal-info.c
+++ b/utils/openal-info.c
@@ -238,15 +238,15 @@ static void printALCSOFTSystemEventIsSupportedResult(LPALCEVENTISSUPPORTEDSOFT a
         return;
     }
     ALCenum supported = alcEventIsSupportedSOFT(eventType, deviceType);
-    if (supported == ALC_EVENT_SUPPORTED)
+    if (supported == ALC_EVENT_SUPPORTED_SOFT)
     {
         printf("SUPPORTED\n");
     }
-    else if (supported == ALC_EVENT_PARTIALLY_SUPPORTED)
+    else if (supported == ALC_EVENT_PARTIALLY_SUPPORTED_SOFT)
     {
         printf("PARTIALLY SUPPORTED\n");
     }
-    else if (supported == ALC_EVENT_NOT_SUPPORTED)
+    else if (supported == ALC_EVENT_NOT_SUPPORTED_SOFT)
     {
         printf("NOT SUPPORTED\n");
     }

--- a/utils/openal-info.c
+++ b/utils/openal-info.c
@@ -230,6 +230,60 @@ static void printModeInfo(ALCdevice *device)
     }
 }
 
+static void printALCSOFTSystemEventIsSupportedResult(LPALCEVENTISSUPPORTEDSOFT alcEventIsSupportedSOFT, ALCenum eventType, ALCenum deviceType)
+{
+    if (alcEventIsSupportedSOFT == NULL)
+    {
+        printf("ERROR (alcEventIsSupportedSOFT missing)\n");
+        return;
+    }
+    ALCenum supported = alcEventIsSupportedSOFT(eventType, deviceType);
+    if (supported == ALC_EVENT_SUPPORTED)
+    {
+        printf("SUPPORTED\n");
+    }
+    else if (supported == ALC_EVENT_PARTIALLY_SUPPORTED)
+    {
+        printf("PARTIALLY SUPPORTED\n");
+    }
+    else if (supported == ALC_EVENT_NOT_SUPPORTED)
+    {
+        printf("NOT SUPPORTED\n");
+    }
+    else
+    {
+        printf("UNEXPECTED RETURN : %d\n", supported);
+    }
+}
+
+static void printALC_SOFT_system_event(void)
+{
+    printf("ALC_SOFT_system_events:");
+    if (alcIsExtensionPresent(NULL, "ALC_SOFT_system_events"))
+    {
+        static LPALCEVENTISSUPPORTEDSOFT alcEventIsSupportedSOFT;
+        alcEventIsSupportedSOFT = FUNCTION_CAST(LPALCEVENTISSUPPORTEDSOFT, alGetProcAddress("alcEventIsSupportedSOFT"));
+        printf(" Supported.\n");
+        printf("    Events:\n");
+        printf("        ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT for ALC_PLAYBACK_DEVICE_SOFT - ");
+        printALCSOFTSystemEventIsSupportedResult(alcEventIsSupportedSOFT, ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT, ALC_PLAYBACK_DEVICE_SOFT);
+        printf("        ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT for ALC_CAPTURE_DEVICE_SOFT - ");
+        printALCSOFTSystemEventIsSupportedResult(alcEventIsSupportedSOFT, ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT, ALC_CAPTURE_DEVICE_SOFT);
+        printf("        ALC_EVENT_TYPE_DEVICE_ADDED_SOFT for ALC_PLAYBACK_DEVICE_SOFT - ");
+        printALCSOFTSystemEventIsSupportedResult(alcEventIsSupportedSOFT, ALC_EVENT_TYPE_DEVICE_ADDED_SOFT, ALC_PLAYBACK_DEVICE_SOFT);
+        printf("        ALC_EVENT_TYPE_DEVICE_ADDED_SOFT for ALC_CAPTURE_DEVICE_SOFT - ");
+        printALCSOFTSystemEventIsSupportedResult(alcEventIsSupportedSOFT, ALC_EVENT_TYPE_DEVICE_ADDED_SOFT, ALC_CAPTURE_DEVICE_SOFT);
+        printf("        ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT for ALC_PLAYBACK_DEVICE_SOFT - ");
+        printALCSOFTSystemEventIsSupportedResult(alcEventIsSupportedSOFT, ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT, ALC_PLAYBACK_DEVICE_SOFT);
+        printf("        ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT for ALC_CAPTURE_DEVICE_SOFT - ");
+        printALCSOFTSystemEventIsSupportedResult(alcEventIsSupportedSOFT, ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT, ALC_CAPTURE_DEVICE_SOFT);
+    }
+    else
+    {
+        printf(" Not supported.\n");
+    }
+}
+
 static void printALInfo(void)
 {
     printf("OpenAL vendor string: %s\n", alGetString(AL_VENDOR));
@@ -435,6 +489,7 @@ int main(int argc, char *argv[])
     }
     printALCInfo(device);
     printHRTFInfo(device);
+    printALC_SOFT_system_event();
 
     context = alcCreateContext(device, NULL);
     if(!context || alcMakeContextCurrent(context) == ALC_FALSE)

--- a/utils/openal-info.c
+++ b/utils/openal-info.c
@@ -242,17 +242,13 @@ static void printALCSOFTSystemEventIsSupportedResult(LPALCEVENTISSUPPORTEDSOFT a
     {
         printf("SUPPORTED\n");
     }
-    else if (supported == ALC_EVENT_PARTIALLY_SUPPORTED_SOFT)
-    {
-        printf("PARTIALLY SUPPORTED\n");
-    }
     else if (supported == ALC_EVENT_NOT_SUPPORTED_SOFT)
     {
         printf("NOT SUPPORTED\n");
     }
     else
     {
-        printf("UNEXPECTED RETURN : %d\n", supported);
+        printf("UNEXPECTED VALUE : %d\n", supported);
     }
 }
 


### PR DESCRIPTION
The purpose of this PR are allow to retrieve which events are supported and if events are fully supported or if some case isn't managed for some reason.
 
Here, since extension isn't release, I would like to propose this addition to allow consumer of this extension to known eventual limitation on runtime (Because backend don't implement some event for example)

For exemple only some backends provide system events:
 * pipewire -> Full support of extension
 * wasapi -> Full support of extension
 * pulseaudio -> Support of add and remove devices events only
 * coreaudio -> Support of default device change only
 
Here, for complete this goal, i propose following addition :
 * alcEventIsSupportedSOFT in ALC_SOFT_system_events extension