### PR TITLE
Move logging callback into an OpenAL extension

### DIFF
--- a/alc/export_list.h
+++ b/alc/export_list.h
@@ -374,8 +374,7 @@ inline const FuncExport alcFunctions[]{
     DECL(alGetObjectLabelEXT),
     DECL(alGetObjectLabelDirectEXT),
 
-    /* Extra functions */
-    DECL(alsoft_set_log_callback),
+    DECL(alcLogCallbackSOFT),
 #ifdef ALSOFT_EAX
 }, eaxFunctions[]{
     DECL(EAXGet),

--- a/alc/inprogext.h
+++ b/alc/inprogext.h
@@ -421,8 +421,7 @@ ALenum AL_APIENTRY EAXGetBufferModeDirect(ALCcontext *context, ALuint buffer, AL
 /* Non-standard exports. Not part of any extension. */
 AL_API const ALchar* AL_APIENTRY alsoft_get_version(void) noexcept;
 
-typedef void (ALC_APIENTRY*LPALSOFTLOGCALLBACK)(void *userptr, char level, const char *message, int length) noexcept;
-void ALC_APIENTRY alsoft_set_log_callback(LPALSOFTLOGCALLBACK callback, void *userptr) noexcept;
+/* ALC_SOFT_logging_events */
 
 /* Functions from abandoned extensions. Only here for binary compatibility. */
 AL_API void AL_APIENTRY alSourceQueueBufferLayersSOFT(ALuint src, ALsizei nb,

--- a/core/logging.h
+++ b/core/logging.h
@@ -17,22 +17,28 @@ extern LogLevel gLogLevel;
 extern FILE *gLogFile;
 
 
-using LogCallbackFunc = void(*)(void *userptr, char level, const char *message, int length) noexcept;
+using LogCallbackFunc = void(*)(void *userptr, LogLevel level, const char *entity, int entityLength, const char *message, int messageLength) noexcept;
 
 void al_set_log_callback(LogCallbackFunc callback, void *userptr);
 
 
 #ifdef __USE_MINGW_ANSI_STDIO
-[[gnu::format(gnu_printf,2,3)]]
+[[gnu::format(gnu_printf,3,4)]]
 #else
-[[gnu::format(printf,2,3)]]
+[[gnu::format(printf,3,4)]]
 #endif
-void al_print(LogLevel level, const char *fmt, ...);
+void al_print(LogLevel level, const char *entity, const char *fmt, ...);
 
-#define TRACE(...) al_print(LogLevel::Trace, __VA_ARGS__)
+#define TRACE_FOR(...) al_print(LogLevel::Trace, __VA_ARGS__)
 
-#define WARN(...) al_print(LogLevel::Warning, __VA_ARGS__)
+#define TRACE(...) TRACE_FOR(NULL, __VA_ARGS__)
 
-#define ERR(...) al_print(LogLevel::Error, __VA_ARGS__)
+#define WARN_FOR(...) al_print(LogLevel::Warning, __VA_ARGS__)
+
+#define WARN(...) WARN_FOR(NULL, __VA_ARGS__)
+
+#define ERR_FOR(...) al_print(LogLevel::Error, __VA_ARGS__)
+
+#define ERR(...) ERR_FOR(NULL, __VA_ARGS__)
 
 #endif /* CORE_LOGGING_H */

--- a/include/AL/alext.h
+++ b/include/AL/alext.h
@@ -734,6 +734,17 @@ void ALC_APIENTRY alcEventCallbackSOFT(ALCEVENTPROCTYPESOFT callback, void *user
 #endif
 #endif
 
+#ifndef ALC_SOFT_logging_events
+#define ALC_SOFT_logging_events
+#define ALC_LOG_LEVEL_ERROR_SOFT                 0x19DB
+#define ALC_LOG_LEVEL_WARNING_SOFT               0x19DC
+#define ALC_LOG_LEVEL_TRACE_SOFT                 0x19DE
+typedef void (ALC_APIENTRY*ALCSOFTLOGCALLBACK)(void *userptr, ALCenum level, const char *entity, int entityLength, const char *message, int messageLength) ALC_API_NOEXCEPT17;
+#ifdef AL_ALEXT_PROTOTYPES
+void ALC_APIENTRY alcLogCallbackSOFT(ALCSOFTLOGCALLBACK callback, void *userptr) ALC_API_NOEXCEPT;
+#endif
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The aim here is to enable access to a logging callback through an OpenAL extension (here ALC_SOFT_logging_events).

Logging callback has already been implemented here: #862.

The only difference with the previously implemented callback is the following modifications:

The log level is now represented by an ALCenum
Two new parameters are added:
 * A null terminated string containing the name of the entity issuing the log.
 * The size of the previous parameter

This string, representing the emitter, can be null, if the implementation cannot provide an emitter section. The emitter represents the impacted section, aka the name of the extension, name of method, or name of specification from which the log comes.