### PR TITLE
fix printf format for MinGW

### DIFF
--- a/al/effects/effects.h
+++ b/al/effects/effects.h
@@ -16,8 +16,8 @@ class effect_exception final : public al::base_exception {
     ALenum mErrorCode;
 
 public:
-#ifdef __USE_MINGW_ANSI_STDIO
-    [[gnu::format(gnu_printf, 3, 4)]]
+#ifdef __MINGW32__
+    [[gnu::format(__MINGW_PRINTF_FORMAT, 3, 4)]]
 #else
     [[gnu::format(printf, 3, 4)]]
 #endif

--- a/al/filter.cpp
+++ b/al/filter.cpp
@@ -53,8 +53,8 @@ class filter_exception final : public al::base_exception {
     ALenum mErrorCode;
 
 public:
-#ifdef __USE_MINGW_ANSI_STDIO
-    [[gnu::format(gnu_printf, 3, 4)]]
+#ifdef __MINGW32__
+    [[gnu::format(__MINGW_PRINTF_FORMAT, 3, 4)]]
 #else
     [[gnu::format(printf, 3, 4)]]
 #endif

--- a/alc/backends/base.h
+++ b/alc/backends/base.h
@@ -103,8 +103,8 @@ class backend_exception final : public base_exception {
     backend_error mErrorCode;
 
 public:
-#ifdef __USE_MINGW_ANSI_STDIO
-    [[gnu::format(gnu_printf, 3, 4)]]
+#ifdef __MINGW32__
+    [[gnu::format(__MINGW_PRINTF_FORMAT, 3, 4)]]
 #else
     [[gnu::format(printf, 3, 4)]]
 #endif

--- a/alc/context.h
+++ b/alc/context.h
@@ -186,8 +186,8 @@ struct ALCcontext : public al::intrusive_ref<ALCcontext>, ContextBase {
      */
     void applyAllUpdates();
 
-#ifdef __USE_MINGW_ANSI_STDIO
-    [[gnu::format(gnu_printf, 3, 4)]]
+#ifdef __MINGW32__
+    [[gnu::format(__MINGW_PRINTF_FORMAT, 3, 4)]]
 #else
     [[gnu::format(printf, 3, 4)]]
 #endif

--- a/core/ambdec.cpp
+++ b/core/ambdec.cpp
@@ -42,8 +42,8 @@ enum class ReaderScope {
     HFMatrix,
 };
 
-#ifdef __USE_MINGW_ANSI_STDIO
-[[gnu::format(gnu_printf,2,3)]]
+#ifdef __MINGW32__
+[[gnu::format(__MINGW_PRINTF_FORMAT,2,3)]]
 #else
 [[gnu::format(printf,2,3)]]
 #endif

--- a/core/device.h
+++ b/core/device.h
@@ -320,8 +320,8 @@ struct DeviceBase {
     void renderSamples(void *outBuffer, const uint numSamples, const size_t frameStep);
 
     /* Caller must lock the device state, and the mixer must not be running. */
-#ifdef __USE_MINGW_ANSI_STDIO
-    [[gnu::format(gnu_printf,2,3)]]
+#ifdef __MINGW32__
+    [[gnu::format(__MINGW_PRINTF_FORMAT,2,3)]]
 #else
     [[gnu::format(printf,2,3)]]
 #endif

--- a/core/logging.h
+++ b/core/logging.h
@@ -22,8 +22,8 @@ using LogCallbackFunc = void(*)(void *userptr, char level, const char *message, 
 void al_set_log_callback(LogCallbackFunc callback, void *userptr);
 
 
-#ifdef __USE_MINGW_ANSI_STDIO
-[[gnu::format(gnu_printf,2,3)]]
+#ifdef __MINGW32__
+[[gnu::format(__MINGW_PRINTF_FORMAT,2,3)]]
 #else
 [[gnu::format(printf,2,3)]]
 #endif


### PR DESCRIPTION
With gcc, mingw uses gnu_printf. With clang, printf is used as it does not support gnu_printf. Use the internal header to match this properly.



Probably should add CI.