### PR TITLE
Fix a bug that playback via portaudio does not work at all

### DIFF
--- a/alc/backends/portaudio.cpp
+++ b/alc/backends/portaudio.cpp
@@ -214,7 +214,7 @@ bool PortPlayback::reset()
 void PortPlayback::start()
 {
     const PaError err{Pa_StartStream(mStream)};
-    if(err == paNoError)
+    if(err != paNoError)
         throw al::backend_exception{al::backend_error::DeviceError, "Failed to start playback: %s",
             Pa_GetErrorText(err)};
 }


### PR DESCRIPTION
Currently, playback using portaudio backend does not work at all due to simple but critical mistake. This PR is to fix that.