### PR TITLE
Remove extra ';' from common/almalloc.h

### DIFF
--- a/common/almalloc.h
+++ b/common/almalloc.h
@@ -12,7 +12,7 @@
 
 namespace gsl {
 template<typename T> using owner = T;
-};
+}
 
 
 #define DISABLE_ALLOC                                                         \


### PR DESCRIPTION
To silence the `/__w/Q2RTX/Q2RTX/extern/openal-soft/common/almalloc.h:15:2: warning: extra ';' [-Wpedantic] };` warning