### PR TITLE
Redirect cubic to spline when loading alsoft.ini

### DIFF
--- a/core/voice.cpp
+++ b/core/voice.cpp
@@ -151,8 +151,8 @@ void Voice::InitMixer(std::optional<std::string> resopt)
 		
 		if (al::case_compare(resampler, "cubic"sv) == 0)
 		{
-			WARN("Resampler option \"%s\" is deprecated, using spline\n", resopt->c_str());
-			resampler = "spline"sv;
+            WARN("Resampler option \"%s\" is deprecated, using spline\n", resopt->c_str());
+            resampler = "spline"sv;
 		}
 		else if(al::case_compare(resampler, "sinc4"sv) == 0
             || al::case_compare(resampler, "sinc8"sv) == 0)

--- a/core/voice.cpp
+++ b/core/voice.cpp
@@ -148,8 +148,13 @@ void Voice::InitMixer(std::optional<std::string> resopt)
         };
 
         std::string_view resampler{*resopt};
-        if(al::case_compare(resampler, "cubic"sv) == 0
-            || al::case_compare(resampler, "sinc4"sv) == 0
+		
+		if (al::case_compare(resampler, "cubic"sv) == 0)
+		{
+			WARN("Resampler option \"%s\" is deprecated, using spline\n", resopt->c_str());
+			resampler = "spline"sv;
+		}
+		else if(al::case_compare(resampler, "sinc4"sv) == 0
             || al::case_compare(resampler, "sinc8"sv) == 0)
         {
             WARN("Resampler option \"%s\" is deprecated, using gaussian\n", resopt->c_str());

--- a/core/voice.cpp
+++ b/core/voice.cpp
@@ -149,12 +149,12 @@ void Voice::InitMixer(std::optional<std::string> resopt)
 
         std::string_view resampler{*resopt};
 		
-		if (al::case_compare(resampler, "cubic"sv) == 0)
-		{
+        if (al::case_compare(resampler, "cubic"sv) == 0)
+        {
             WARN("Resampler option \"%s\" is deprecated, using spline\n", resopt->c_str());
             resampler = "spline"sv;
-		}
-		else if(al::case_compare(resampler, "sinc4"sv) == 0
+        }
+        else if(al::case_compare(resampler, "sinc4"sv) == 0
             || al::case_compare(resampler, "sinc8"sv) == 0)
         {
             WARN("Resampler option \"%s\" is deprecated, using gaussian\n", resopt->c_str());


### PR DESCRIPTION
Hi,

First time making a pr here, so let me know if I did anything wrong/need to provide more info.

Recently, I updated to the latest version of openal soft, and noticed that the audio in the game sounded weird. Turns out, it's because I was using the cubic resampler, and that was being routed to gaussian in the ini. Since spline is the nearest replacement, I changed it in my ini and verified it sounds now as I expect it.

I figured that I would submit a PR here so that others don't have the same problem.