### PR TITLE
Build for Android (32 and 64-bit) and upload as workflow artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         - {
             name: "Android_armeabi-v7a-Release",
             os: ubuntu-latest,
-            cmake_opts: "-DCMAKE_TOOLCHAIN_FILE=/usr/local/lib/android/sdk/ndk/26.3.11579264/build/cmake/android.toolchain.cmake \
+            cmake_opts: "-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
             -DALSOFT_EMBED_HRTF_DATA=TRUE \
             -DALSOFT_REQUIRE_OPENSL=ON",
             build_type: "Release"
@@ -119,7 +119,7 @@ jobs:
             os: ubuntu-latest,
             cmake_opts: "-DANDRIOD_ABI=arm64-v8a \
             -DANDROID_PLATFORM=25 \
-            -DCMAKE_TOOLCHAIN_FILE=/usr/local/lib/android/sdk/ndk/26.3.11579264/build/cmake/android.toolchain.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
             -DALSOFT_EMBED_HRTF_DATA=TRUE \
             -DALSOFT_REQUIRE_OPENSL=ON",
             build_type: "Release"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,6 @@ jobs:
             cmake_opts: "-DCMAKE_TOOLCHAIN_FILE=/usr/local/lib/android/sdk/ndk/26.3.11579264/build/cmake/android.toolchain.cmake \
             -DALSOFT_EMBED_HRTF_DATA=TRUE \
             -DALSOFT_REQUIRE_OPENSL=ON",
-            deps_cmdline: "sudo apt update && sudo apt-get install -qq \
-              libpulse-dev \
-              portaudio19-dev \
-              libasound2-dev \
-              libjack-dev \
-              libpipewire-0.3-dev \
-              qtbase5-dev \
-              libdbus-1-dev",
             build_type: "Release"
           }
         - {
@@ -130,14 +122,6 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=/usr/local/lib/android/sdk/ndk/26.3.11579264/build/cmake/android.toolchain.cmake \
             -DALSOFT_EMBED_HRTF_DATA=TRUE \
             -DALSOFT_REQUIRE_OPENSL=ON",
-            deps_cmdline: "sudo apt update && sudo apt-get install -qq \
-              libpulse-dev \
-              portaudio19-dev \
-              libasound2-dev \
-              libjack-dev \
-              libpipewire-0.3-dev \
-              qtbase5-dev \
-              libdbus-1-dev",
             build_type: "Release"
           }
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,40 @@ jobs:
               libdbus-1-dev",
             build_type: "Release"
           }
-
+        - {
+            name: "Android_armeabi-v7a-Release",
+            os: ubuntu-latest,
+            cmake_opts: "-DCMAKE_TOOLCHAIN_FILE=/usr/local/lib/android/sdk/ndk/26.3.11579264/build/cmake/android.toolchain.cmake \
+            -DALSOFT_EMBED_HRTF_DATA=TRUE \
+            -DALSOFT_REQUIRE_OPENSL=ON",
+            deps_cmdline: "sudo apt update && sudo apt-get install -qq \
+              libpulse-dev \
+              portaudio19-dev \
+              libasound2-dev \
+              libjack-dev \
+              libpipewire-0.3-dev \
+              qtbase5-dev \
+              libdbus-1-dev",
+            build_type: "Release"
+          }
+        - {
+            name: "Android_arm64-v8a-Release",
+            os: ubuntu-latest,
+            cmake_opts: "-DANDRIOD_ABI=arm64-v8a \
+            -DANDROID_PLATFORM=25 \
+            -DCMAKE_TOOLCHAIN_FILE=/usr/local/lib/android/sdk/ndk/26.3.11579264/build/cmake/android.toolchain.cmake \
+            -DALSOFT_EMBED_HRTF_DATA=TRUE \
+            -DALSOFT_REQUIRE_OPENSL=ON",
+            deps_cmdline: "sudo apt update && sudo apt-get install -qq \
+              libpulse-dev \
+              portaudio19-dev \
+              libasound2-dev \
+              libjack-dev \
+              libpipewire-0.3-dev \
+              qtbase5-dev \
+              libdbus-1-dev",
+            build_type: "Release"
+          }
     steps:
     - uses: actions/checkout@v4
 
@@ -133,8 +166,8 @@ jobs:
         cd build
         ctest
 
-    - name: Create Archive
-      if: ${{ matrix.config.os == 'windows-latest' }}
+    - name: Set up Windows artifacts
+      if: ${{ contains(matrix.config.name, 'Win') }}
       shell: bash
       run: |
         cd build
@@ -143,10 +176,17 @@ jobs:
         cp ${{matrix.config.build_type}}/soft_oal.dll archive
         cp ${{matrix.config.build_type}}/OpenAL32.dll archive/router
 
-    - name: Upload Archive
-      # Upload package as an artifact of this workflow.
+    - name: Set up Android artifacts
+      if: ${{ contains(matrix.config.name, 'Android') }}
+      shell: bash
+      run: |
+        cd build
+        mkdir archive
+        cp ${{github.workspace}}/build/libopenal.so archive/
+
+    - name: Upload build as a workflow artifact
       uses: actions/upload-artifact@v4
-      if: ${{ matrix.config.os == 'windows-latest' }}
+      if: ${{ contains(matrix.config.name, 'Win') || contains(matrix.config.name, 'Android') }}
       with:
         name: soft_oal-${{matrix.config.name}}
         path: build/archive


### PR DESCRIPTION
Context: https://github.com/kcat/openal-soft/issues/1010 and https://github.com/kcat/openal-soft/issues/824
This builds [32-bit/armeabi-v7a](https://github.com/ThreeDeeJay/openal-soft/actions/runs/10224078457/artifacts/1771370955)  and [64-bit/arm64-v8a](https://github.com/ThreeDeeJay/openal-soft/actions/runs/10224078457/artifacts/1771371327) libopenal.so for Android that can replace older/generic OpenAL library from Android apps/games (if using root to access `/data/app/*hash*/*package*/lib/...`), or just include it in an android app/game rebuilt from source. Tested in [sView](https://youtu.be/ssmLgkbRMh0) (32-bit) and IdTech4A/Quake4 (64-bit).

Though apparently an update in android or something on my end broke apps' ability to load `/etc/openal/alsoftrc.config` (the only location that [worked for me to load external MHRs](https://github.com/kcat/openal-soft/issues/824#issuecomment-1937867413)) so I wonder if it would be possible to force HRTF on by default without relying on a config file since[ it doesn't even load the config or MHR from the supposed executable/working directory (`/system/bin/`](https://i.imgur.com/Mv0R1Qb.png) like it does on Windows. 🤔 