### PR TITLE
Upgrade makemhr workflow to build and upload utils

### DIFF
--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         git clone https://github.com/ThreeDeeJay/libmysofa.git
         cd libmysofa
-        git checkout e72a8e1b06cab2c77b913e59f017667710c40ba9
+        git checkout 8642646ee6caca9085456bfa9d731200d68c25ca
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -1,10 +1,10 @@
-name: makemhr
+name: utils
 
 on:
   push:
     paths:
-      - 'utils/makemhr/**'
-      - '.github/workflows/makemhr.yml'
+      - 'utils/**'
+      - '.github/workflows/utils.yml'
 
   workflow_dispatch:
 
@@ -25,7 +25,7 @@ jobs:
       run: echo "CommitHash=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
 
     - name: Clone libmysofa
-      run: git clone --depth 1 --branch v1.3.1 https://github.com/hoene/libmysofa.git libmysofa
+      run: git clone --depth 1 https://github.com/ThreeDeeJay/libmysofa.git
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3
@@ -52,25 +52,30 @@ jobs:
     - name: Collect artifacts
       run: |
         copy "build/Release/makemhr.exe" "Artifacts/makemhr.exe"
+        copy "build/Release/sofa-info.exe" "Artifacts/sofa-info.exe"
+        copy "build/Release/alrecord.exe" "Artifacts/alrecord.exe"
+        copy "build/Release/altonegen.exe" "Artifacts/altonegen.exe"
+        copy "build/Release/openal-info.exe" "Artifacts/openal-info.exe"
+        copy "build/Release/allafplay.exe" "Artifacts/allafplay.exe"
         copy "libmysofa/windows/third-party/zlib-1.2.11/bin/zlib.dll" "Artifacts/zlib.dll"
 
-    - name: Upload makemhr artifact
+    - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: makemhr
+        name: utils
         path: "Artifacts/"
 
     - name: Compress artifacts
       uses: papeloto/action-zip@v1
       with:
         files: Artifacts/
-        dest: "Release/makemhr.zip"
+        dest: "Release/utils.zip"
 
     - name: GitHub pre-release
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{secrets.GITHUB_TOKEN}}"
-        automatic_release_tag: "makemhr"
+        automatic_release_tag: "utils"
         prerelease: true
-        title: "[${{env.CurrentDate}}] makemhr-${{env.CommitHash}}"
-        files: "Release/makemhr.zip"
+        title: "[${{env.CurrentDate}}] utils-${{env.CommitHash}}"
+        files: "Release/utils.zip"

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Clone libmysofa
       run: |
         git clone https://github.com/ThreeDeeJay/libmysofa.git
+        cd libmysofa
         git checkout e72a8e1b06cab2c77b913e59f017667710c40ba9
 
     - name: Add MSBuild to PATH

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -25,7 +25,9 @@ jobs:
       run: echo "CommitHash=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
 
     - name: Clone libmysofa
-      run: git clone --depth 1 --branch e72a8e1b06cab2c77b913e59f017667710c40ba9 https://github.com/ThreeDeeJay/libmysofa.git
+      run: |
+        git clone https://github.com/ThreeDeeJay/libmysofa.git
+        git checkout e72a8e1b06cab2c77b913e59f017667710c40ba9
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -25,7 +25,7 @@ jobs:
       run: echo "CommitHash=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
 
     - name: Clone libmysofa
-      run: git clone --depth 1 https://github.com/ThreeDeeJay/libmysofa.git
+      run: git clone --depth 1 --branch v1.3.2 https://github.com/hoene/libmysofa.git
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -25,7 +25,7 @@ jobs:
       run: echo "CommitHash=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
 
     - name: Clone libmysofa
-      run: git clone --depth 1 --branch v1.3.2 https://github.com/hoene/libmysofa.git
+      run: git clone --depth 1 --branch e72a8e1b06cab2c77b913e59f017667710c40ba9 https://github.com/ThreeDeeJay/libmysofa.git
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   BUILD_TYPE: Release
+  Branch: ${{github.ref_name}}
 
 jobs:
   Win64:
@@ -17,7 +18,7 @@ jobs:
 
     steps:
     - name: Clone repo and submodules
-      run: git clone https://github.com/${{github.repository}}.git .
+      run: git clone https://github.com/${{github.repository}}.git . --branch ${{env.Branch}}
 
     - name: Get current date, commit hash and count
       run: |

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         echo "CommitDate=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" >> $env:GITHUB_ENV
         echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
-        echo "CommitCount=$(git rev-list --count ${{env.Branch}})" >> $env:GITHUB_ENV
+        echo "CommitCount=$(git rev-list --count ${{env.Branch}} --)" >> $env:GITHUB_ENV
 
     - name: Clone libmysofa
       run: |

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -16,13 +16,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Clone repo and submodules
+      run: git clone https://github.com/${{github.repository}}.git .
 
-    - name: Get current date
-      run: echo "CurrentDate=$(date +'%Y-%m-%d')" >> $env:GITHUB_ENV
-
-    - name: Get commit hash
-      run: echo "CommitHash=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
+    - name: Get current date, commit hash and count
+      run: |
+        echo "CommitDate=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" >> $env:GITHUB_ENV
+        echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
+        echo "CommitCount=$(git rev-list --count ${{env.Branch}})" >> $env:GITHUB_ENV
 
     - name: Clone libmysofa
       run: |
@@ -65,7 +66,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: utils
+        name: ${{env.CommitDate}}_utils-r${{env.CommitCount}}@${{env.CommitHashShort}}
         path: "Artifacts/"
 
     - name: Compress artifacts
@@ -80,5 +81,5 @@ jobs:
         repo_token: "${{secrets.GITHUB_TOKEN}}"
         automatic_release_tag: "utils"
         prerelease: true
-        title: "[${{env.CurrentDate}}] utils-${{env.CommitHash}}"
+        title: "[${{env.CommitDate}}] utils-r${{env.CommitCount}}@${{env.CommitHashShort}}"
         files: "Release/utils.zip"


### PR DESCRIPTION
- Includes makemhr, sofa-info, alrecord, altonegen, openal-info and allafplay Windows executables in [utils.zip](https://github.com/ThreeDeeJay/openal-soft/releases/download/utils/utils.zip)
- Uses my libmysofa fork that fixed the `Invalid format` error by removing a [filesize/density limit](https://github.com/hoene/libmysofa/issues/195#issuecomment-1370881871), so that makemhr is able to convert larger SOFA files (like [EAC](https://github.com/davircarvalho/Individualized_HRTF_Synthesis) HRTFs with 5° elevations/azimuths)
[v1.3.2](https://github.com/hoene/libmysofa/releases/tag/v1.3.2) (latest upstream)
![image](https://github.com/user-attachments/assets/f4fa3173-7a63-48c0-8e60-cdaac717e6f6)
[My fork](https://github.com/hoene/libmysofa/compare/main...ThreeDeeJay:libmysofa:main) (just a two-liner so let me know if you'd rather fork and remove limit yourself or if I should revert to the limited official branch)
![image](https://github.com/user-attachments/assets/93ce0d84-19f0-4293-ab1a-9193b5891ac7)

I've had this branch for a while and was reminded of it [here](https://github.com/kcat/openal-soft/issues/1015#issuecomment-2238809390) and then I recently saw https://github.com/kcat/openal-soft/commit/3b10c6f9bc83e535f5de119f668ce6fd17e4e67d and wanted to try it out so I figured it'd be a good time to share this new workflow. Which by the way, is playback supposed to work or is it still a WIP? When I try the LAF files I posted [here](https://github.com/kcat/openal-soft/issues/999#issuecomment-2241620606), I just get a channel breakdown and it immediately exits the process without playing any audio 🤔 
![image](https://github.com/user-attachments/assets/1908825b-8ca3-4837-af6f-7a198afa543d)
