### PR TITLE
Remove "v" from commit hash in release title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,5 +236,5 @@ jobs:
         repo_token: "${{secrets.GITHUB_TOKEN}}"
         automatic_release_tag: "latest"
         prerelease: true
-        title: "OpenAL Soft v${{needs.build.outputs.CommitTag}}-v${{needs.build.outputs.CommitHashShort}}"
+        title: "OpenAL Soft v${{needs.build.outputs.CommitTag}}-${{needs.build.outputs.CommitHashShort}}"
         files: "build/release/*"


### PR DESCRIPTION
Fixes a minor typo from https://github.com/kcat/openal-soft/pull/1008
![image](https://github.com/user-attachments/assets/2ee61af9-b5c4-4d68-b382-055afeebee84)
