### PR TITLE
Enable Jack on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,12 @@ jobs:
               -DALSOFT_BUILD_ROUTER=ON \
               -DALSOFT_REQUIRE_WINMM=ON \
               -DALSOFT_REQUIRE_DSOUND=ON \
-              -DALSOFT_REQUIRE_WASAPI=ON",
-            build_type: "Release"
+              -DALSOFT_REQUIRE_WASAPI=ON \
+              -DALSOFT_REQUIRE_JACK=ON \
+              -DJACK_INCLUDE_DIR=\"C:\\Program Files (x86)\\JACK2\\include\" \
+              -DJACK_LIBRARY=\"C:\\Program Files\\JACK2\\lib32\\libjack.lib\"",
+            build_type: "Release",
+            architecture: "Win32"
           }
         - {
             name: "Win32-Debug",
@@ -29,8 +33,12 @@ jobs:
               -DALSOFT_BUILD_ROUTER=ON \
               -DALSOFT_REQUIRE_WINMM=ON \
               -DALSOFT_REQUIRE_DSOUND=ON \
-              -DALSOFT_REQUIRE_WASAPI=ON",
-            build_type: "Debug"
+              -DALSOFT_REQUIRE_WASAPI=ON \
+              -DALSOFT_REQUIRE_JACK=ON \
+              -DJACK_INCLUDE_DIR=\"C:\\Program Files (x86)\\JACK2\\include\" \
+              -DJACK_LIBRARY=\"C:\\Program Files\\JACK2\\lib32\\libjack.lib\"",
+            build_type: "Debug",
+            architecture: "Win32"
           }
         - {
             name: "Win64-Release",
@@ -40,8 +48,12 @@ jobs:
               -DALSOFT_BUILD_ROUTER=ON \
               -DALSOFT_REQUIRE_WINMM=ON \
               -DALSOFT_REQUIRE_DSOUND=ON \
-              -DALSOFT_REQUIRE_WASAPI=ON",
-            build_type: "Release"
+              -DALSOFT_REQUIRE_WASAPI=ON \
+              -DALSOFT_REQUIRE_JACK=ON \
+              -DJACK_INCLUDE_DIR=\"C:\\Program Files\\JACK2\\include\" \
+              -DJACK_LIBRARY=\"C:\\Program Files\\JACK2\\lib\\libjack64.lib\"",
+            build_type: "Release",
+            architecture: "Win64"
           }
         - {
             name: "Win64-Debug",
@@ -51,8 +63,12 @@ jobs:
               -DALSOFT_BUILD_ROUTER=ON \
               -DALSOFT_REQUIRE_WINMM=ON \
               -DALSOFT_REQUIRE_DSOUND=ON \
-              -DALSOFT_REQUIRE_WASAPI=ON",
-            build_type: "Debug"
+              -DALSOFT_REQUIRE_WASAPI=ON \
+              -DALSOFT_REQUIRE_JACK=ON \
+              -DJACK_INCLUDE_DIR=\"C:\\Program Files\\JACK2\\include\" \
+              -DJACK_LIBRARY=\"C:\\Program Files\\JACK2\\lib\\libjack64.lib\"",
+            build_type: "Debug",
+            architecture: "Win64"
           }
         - {
             name: "Win64-UWP",
@@ -62,8 +78,12 @@ jobs:
               -DCMAKE_SYSTEM_NAME=WindowsStore \
               \"-DCMAKE_SYSTEM_VERSION=10.0\" \
               -DALSOFT_BUILD_ROUTER=ON \
-              -DALSOFT_REQUIRE_WASAPI=ON",
-            build_type: "Release"
+              -DALSOFT_REQUIRE_WASAPI=ON \
+              -DALSOFT_REQUIRE_JACK=ON \
+              -DJACK_INCLUDE_DIR=\"C:\\Program Files\\JACK2\\include\" \
+              -DJACK_LIBRARY=\"C:\\Program Files\\JACK2\\lib\\libjack64.lib\"",
+            build_type: "Release",
+            architecture: "Win64"
           }
         - {
             name: "macOS-Release",
@@ -142,6 +162,13 @@ jobs:
         if [[ ! -z "${{matrix.config.deps_cmdline}}" ]]; then
           eval ${{matrix.config.deps_cmdline}}
         fi
+
+    - name: Install Jack
+      if: ${{ contains(matrix.config.name, 'Win') }}
+      shell: powershell
+      run: |
+        Invoke-WebRequest -Method Get -Uri https://github.com/jackaudio/jack2-releases/releases/download/v1.9.22/jack2-${{matrix.config.architecture}}-v1.9.22.exe -UseBasicParsing -OutFile jack.exe
+        Start-Process -Wait jack.exe -ArgumentList "/VERYSILENT"
 
     - name: Configure
       shell: bash


### PR DESCRIPTION
Following [this suggestion to try Jack on Windows](https://github.com/kcat/openal-soft/issues/999#issuecomment-2294123536), I decided to give it a shot, but found out that just setting `drivers=jack` wasn't enough: the backend was not enabled for Windows builds. So I managed to install the dependencies and build it here.
https://github.com/ThreeDeeJay/openal-soft/actions/runs/10440094213

However, I was still not able to get it working. I'm not sure if it's an issue with OpenAL Soft, Jack, PortAudio, ASIO, or something else on my end, but it can't even establish an active connection/stream via the Jack control panel (which btw is unnervingly buggy for an app that deals with ASIO 👀💦 )
![image](https://github.com/user-attachments/assets/1c291e35-b1fc-4e6e-9995-332fc524cb46)
Changing buffer or sample rate doesn't help, though fwiw the [dummy backend in Jack seems to play nice with ASIO4ALL](https://github.com/user-attachments/assets/728bdac7-01b6-47b5-8331-3e659048cae9) (though 32000hz is the highest sample rate without ["XRuns"](https://i.imgur.com/xG9rhrC.png) (underruns?) warnings)

Anyhow, when attempting to use Jack in OpenAL Soft, the apps fail to open the device no matter what I do:
![ALCapsViewer32_CwwUNS7JE7](https://github.com/user-attachments/assets/0cc6e4ec-c8a5-437d-87c7-9c75d207aa3b)

Test build with config and logs: [OpenALSoftJackTest.zip](https://github.com/user-attachments/files/16648235/OpenALSoftJackTest.zip)

Something to note: for some reason, the [Jack installers](https://github.com/jackaudio/jack2-releases/releases) copy DLLs to `C:\Windows` instead of `C:\Windows\System32`/`C:\Windows\SysWOW64` so I had to copy them manually to the executable folder. Also, OpenAL Soft Win64 looks for `libjack.dll` even though the file added by Jack is `libjack64.dll`.

I know this sounds more like an issue but even though I'm not really fond of the friction it takes to set this up, I figured I'd still share the CI in case someone can figure out how to get this working and maybe then this could be [eventually](https://github.com/kcat/openal-soft/issues/1030#issuecomment-2287727324) merged so people don't have to go out of their way to compile with Jack.