### PR TITLE
Fix for Steam Deck crashing on loading the OpenALSoft library.

### DIFF
--- a/common/polyphase_resampler.cpp
+++ b/common/polyphase_resampler.cpp
@@ -71,6 +71,33 @@ double Sinc(const double x)
     return std::sin(al::numbers::pi*x) / (al::numbers::pi*x);
 }
 
+/* The zero-order modified Bessel function of the first kind, used for the
+ * Kaiser window.
+ *
+ *   I_0(x) = sum_{k=0}^inf (1 / k!)^2 (x / 2)^(2 k)
+ *          = sum_{k=0}^inf ((x / 2)^k / k!)^2
+ */
+constexpr double BesselI_0(const double x)
+{
+    // Start at k=1 since k=0 is trivial.
+    const double x2{x/2.0};
+    double term{1.0};
+    double sum{1.0};
+    int k{1};
+
+    // Let the integration converge until the term of the sum is no longer
+    // significant.
+    double last_sum{};
+    do {
+        const double y{x2 / k};
+        ++k;
+        last_sum = sum;
+        term *= y * y;
+        sum += term;
+    } while(sum != last_sum);
+    return sum;
+}
+
 /* Calculate a Kaiser window from the given beta value and a normalized k
  * [-1, 1].
  *
@@ -89,7 +116,7 @@ double Kaiser(const double beta, const double k, const double besseli_0_beta)
 {
     if(!(k >= -1.0 && k <= 1.0))
         return 0.0;
-    return cyl_bessel_i(0, beta * std::sqrt(1.0 - k*k)) / besseli_0_beta;
+    return BesselI_0(beta * std::sqrt(1.0 - k*k)) / besseli_0_beta;
 }
 
 /* Calculates the size (order) of the Kaiser window.  Rejection is in dB and
@@ -158,7 +185,7 @@ void PPhaseResampler::init(const uint srcRate, const uint dstRate)
     // calculating the left offset to avoid increasing the transition width.
     const uint l{(CalcKaiserOrder(180.0, width)+1) / 2};
     const double beta{CalcKaiserBeta(180.0)};
-    const double besseli_0_beta{cyl_bessel_i(0, beta)};
+    const double besseli_0_beta{BesselI_0(beta)};
     mM = l*2 + 1;
     mL = l;
     mF.resize(mM);


### PR DESCRIPTION
This PR fixes an issue where the library will not load on the Steam Deck. When I try to run my game with a newer version of OpenALSoft from master I get the error "0x not found in file . (0x8007013D)". The fix described below will fix this issue and allow it to run. Everything is fine on Windows.

This PR is simply a revert of the commit 33cd77b81b1dce9a5b55ec7e215315c500f9d0bf (* Use the C++ standard's regular modified Bessel function). However, if you decided to take this code you might want to review it, since I have no idea what it should do and I had to fix a couple of merge conflicts.

I'm not sure if this is something that should be fixed at this level, since you should be able to use the standard c++ functions, but maybe there is an issue with the implementation of them on Proton or something like that. Not an issue for this project to fix, but if someone else is like me and wants the latest version reverting that commit will make it work.

In my case I wanted to make use of the events to reload the audio device when it changes. To get the full api for that I have to go past the version that has this breaking change on the Deck.