### PR TITLE
Switch to the official libmysofa repo

### DIFF
--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Clone libmysofa
       run: |
-        git clone https://github.com/ThreeDeeJay/libmysofa.git
+        git clone https://github.com/hoene/libmysofa.git
         cd libmysofa
-        git checkout 8642646ee6caca9085456bfa9d731200d68c25ca
+        git checkout 2297dd8224ccf42882a2546f2c7ee02e7ab0d1ba
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3


### PR DESCRIPTION
I decided to submit [your suggestion to set a higher but safe SOFA limit](https://github.com/kcat/openal-soft/pull/1026#issuecomment-2268680856) as a [PR in the official libmysofa repo](https://github.com/hoene/libmysofa/pull/221) and thankfully it was accepted and merged. So I figured it's time to switch off my temporary fork and use the latest official commit directly.

To verify it, you can try the [test with old makemhr](https://www.dropbox.com/s/ow1f3t46tw4tuvr/makemhr-f176484%2BEAC.SOFA-05ac8cc_InvalidFormat.7z?dl=1) which should fail with `Invalid error`
And updating makemhr.exe to [the new one](https://github.com/ThreeDeeJay/openal-soft/releases/download/utils/utils.zip) should allow converting it:

```
Generating "EAC_Default_CustomGrid_-90_90_5_0_360_5_48kHz_UniqueCartesianCoordinates-48000.mhr"
Using 2 threads.
Reading HRTF data from EAC_Default_CustomGrid_-90_90_5_0_360_5_48kHz_UniqueCartesianCoordinates.sofa...
Unexpected delay attribute: _Netcdf4Coordinates = <null>
Unexpected IR attribute: _Netcdf4Coordinates = <null>
Detecting compatible layout...
Using 2394 of 2506 IRs.
Loading HRIRs... 2506 of 2506
Calculating HRIR onsets... 4788 of 4788
Calculating HRIR magnitudes... 4788 of 4788
Calculating diffuse-field average...
Performing diffuse-field equalization...
Synthesizing missing elevations...
Performing minimum phase reconstruction...
100% done (4788 of 4788)
Truncating minimum-phase HRIRs...
Normalizing final HRIRs...
Calculating impulse delays...
Creating MHR data set Output\EAC_Default_CustomGrid_-90_90_5_0_360_5_48kHz_UniqueCartesianCoordinates\EAC_Default_CustomGrid_-90_90_5_0_360_5_48kHz_UniqueCartesianCoordinates-48000.mhr...
Operation completed.
```