### PR TITLE
Update libmysofa to stable release (v1.3.3)

### DIFF
--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -28,9 +28,9 @@ jobs:
 
     - name: Clone libmysofa
       run: |
-        git clone https://github.com/ThreeDeeJay/libmysofa.git
+        git clone https://github.com/hoene/libmysofa.git
         cd libmysofa
-        git checkout 8642646ee6caca9085456bfa9d731200d68c25ca
+        git checkout 2297dd8224ccf42882a2546f2c7ee02e7ab0d1ba
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3

--- a/.github/workflows/utils.yml
+++ b/.github/workflows/utils.yml
@@ -29,9 +29,7 @@ jobs:
 
     - name: Clone libmysofa
       run: |
-        git clone https://github.com/hoene/libmysofa.git
-        cd libmysofa
-        git checkout 2297dd8224ccf42882a2546f2c7ee02e7ab0d1ba
+        git clone https://github.com/hoene/libmysofa.git --branch v1.3.3
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3


### PR DESCRIPTION
Apparently the previous fix caused some [build errors](https://github.com/hoene/libmysofa/issues/224) which were fixed [here](https://github.com/hoene/libmysofa/pull/226), which is included in the [latest stable release](https://github.com/hoene/libmysofa/releases/tag/latest).