### PR TITLE
Only use noexcept in public headers on >= C++11

### DIFF
--- a/include/AL/al.h
+++ b/include/AL/al.h
@@ -5,9 +5,19 @@
 #ifdef __cplusplus
 extern "C" {
 
+#ifdef _MSVC_LANG
+#define AL_CPLUSPLUS _MSVC_LANG
+#else
+#define AL_CPLUSPLUS __cplusplus
+#endif
+
 #ifndef AL_DISABLE_NOEXCEPT
+#if AL_CPLUSPLUS >= 201103L
 #define AL_API_NOEXCEPT noexcept
-#if __cplusplus >= 201703L
+#else
+#define AL_API_NOEXCEPT
+#endif
+#if AL_CPLUSPLUS >= 201703L
 #define AL_API_NOEXCEPT17 noexcept
 #else
 #define AL_API_NOEXCEPT17
@@ -18,6 +28,8 @@ extern "C" {
 #define AL_API_NOEXCEPT
 #define AL_API_NOEXCEPT17
 #endif
+
+#undef AL_CPLUSPLUS
 
 #else /* __cplusplus */
 

--- a/include/AL/alc.h
+++ b/include/AL/alc.h
@@ -5,9 +5,19 @@
 #ifdef __cplusplus
 extern "C" {
 
+#ifdef _MSVC_LANG
+#define ALC_CPLUSPLUS _MSVC_LANG
+#else
+#define ALC_CPLUSPLUS __cplusplus
+#endif
+
 #ifndef AL_DISABLE_NOEXCEPT
+#if ALC_CPLUSPLUS >= 201103L
 #define ALC_API_NOEXCEPT noexcept
-#if __cplusplus >= 201703L
+#else
+#define ALC_API_NOEXCEPT
+#endif
+#if ALC_CPLUSPLUS >= 201703L
 #define ALC_API_NOEXCEPT17 noexcept
 #else
 #define ALC_API_NOEXCEPT17
@@ -18,6 +28,8 @@ extern "C" {
 #define ALC_API_NOEXCEPT
 #define ALC_API_NOEXCEPT17
 #endif
+
+#undef ALC_CPLUSPLUS
 
 #else /* __cplusplus */
 


### PR DESCRIPTION
This resolves issues consuming openal-soft in projects that don't explicitly specify a C++ standard of C++11 or newer.

This also handles the fact that `__cplusplus` is not set properly in MSVC (always claiming to be 199711L) which prevented both the C++11 noexcept and the C++17 noexcept annotations from taking effect.

(See https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/ for details, including the mandatory command-line option to opt-in to standard `__cplusplus` behaviour)