### PR TITLE
Update bindings list to include LWJGL and Multiplatform OpenAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Java bindings for the OpenAL API, usable with OpenAL Soft. It also includes a
 higher level Sound3D Toolkit API and utility functions to make easier use of
 OpenAL features and capabilities.
 
+Kotlin Bindings:
+* [Multiplatform OpenAL](https://git.karmakrafts.dev/kk/multiplatform-openal), developed for the Kleaver project,
+includes Kotlin/Native bindings for the OpenAL API, based on OpenAL Soft with support
+for Windows x64, Linux x64/arm64, macOS x64/arm64, iOS x64/arm64 and Android x64/arm64/arm32.
+
 Python Bindings:
 * [PyOpenAL](https://pypi.org/project/PyOpenAL/). Also includes methods to play
 wave files and, with PyOgg, also Vorbis, Opus, and FLAC.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ API, including some extensions. It also includes utility libraries for math and
 linear algebra, which can be useful for 3D calculations.
 
 Java Bindings:
+* [LWJGL](https://github.com/LWJGL/lwjgl3), the Lightweight Java Game Library,
+includes Java bindings for the OpenAL API, usable with OpenAL Soft.
 * [JOAL](https://jogamp.org/joal/www/), part of the JogAmp project, includes
 Java bindings for the OpenAL API, usable with OpenAL Soft. It also includes a
 higher level Sound3D Toolkit API and utility functions to make easier use of

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ OpenAL features and capabilities.
 Kotlin Bindings:
 * [Multiplatform OpenAL](https://git.karmakrafts.dev/kk/multiplatform-openal), developed for the Kleaver project,
 includes Kotlin/Native bindings for the OpenAL API, based on OpenAL Soft with support
-for Windows x64, Linux x64/arm64, macOS x64/arm64, iOS x64/arm64 and Android x64/arm64/arm32.
+for Windows, Linux, macOS, iOS and Android.
 
 Python Bindings:
 * [PyOpenAL](https://pypi.org/project/PyOpenAL/). Also includes methods to play


### PR DESCRIPTION
Just a small update to the bindings list to include LWJGL as another Java wrapper and Multiplatform OpenAL for Kotlin/Native from myself.