### PR TITLE
WASAPI exclusive config

### DIFF
--- a/configs/HRTF+WASAPI Exclusive/alsoft.ini
+++ b/configs/HRTF+WASAPI Exclusive/alsoft.ini
@@ -1,0 +1,8 @@
+[General]
+channels=stereo
+stereo-mode=headphones
+stereo-encoding=hrtf
+period_size=1
+
+[wasapi]
+exclusive-mode=true

--- a/configs/WASAPI Exclusive/alsoft.ini
+++ b/configs/WASAPI Exclusive/alsoft.ini
@@ -1,0 +1,5 @@
+[General]
+period_size=1
+
+[wasapi]
+exclusive-mode=true


### PR DESCRIPTION
Minimal drop-in configuration to enable WASAPI exclusive at the lowest available buffer/period size as well as another config with HRTF also enabled since it can benefit from lower latency for slightly higher binaural accuracy like during fast sound or camera movements.
I was considering making GitHub actions generate separate pre-configured builds with it but that seems like overkill, unless there's more demand for low latency in the future 🤔 