### PR TITLE
set cmake_minimum_required version to 3.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake build file list for OpenAL
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.26)
 enable_testing()
 
 if(APPLE)


### PR DESCRIPTION
Generator expression BUILD_LOCAL_INTERFACE requires cmake minimum version 3.26