### PR TITLE
Always run release job, ignoring Apple build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
       CommitDate: ${{env.CommitDate}}
 
   release:
-    if: github.event_name != 'pull_request'
+    if: always() && github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Simple workaround for https://github.com/kcat/openal-soft/issues/1152, so that Windows builds are released again even if MacOS and iOS builds fail.

![image](https://github.com/user-attachments/assets/86d092e1-5487-40de-b4b5-1f2f706ded3f)

https://github.com/ThreeDeeJay/openal-soft/releases/tag/latest