### PR TITLE
Fix for `GetHrtfResource` when `ALSOFT_EMBED_HRTF_DATA` isnt defined.

### DIFF
--- a/core/hrtf_resource.cpp
+++ b/core/hrtf_resource.cpp
@@ -8,7 +8,7 @@
 
 #ifndef ALSOFT_EMBED_HRTF_DATA
 
-auto GetResource(int name [[maybe_unused]]) noexcept -> std::span<const char>
+auto GetHrtfResource(int name [[maybe_unused]]) noexcept -> std::span<const char>
 { return {}; }
 
 #else


### PR DESCRIPTION
When `ALSOFT_EMBED_HRTF_DATA` isn’t defined, the code defines a function called `GetResource` instead of `GetHrtfResource`, which leads to an unresolved symbol at link time.

<img width="1820" height="116" alt="{D35B7C5F-5BA7-42E5-AAC6-B8D4420449ED}" src="https://github.com/user-attachments/assets/76220796-8b5d-450e-9405-fda56a2dfeba" />
