### PR TITLE
Fix missing cstdint header

### DIFF
--- a/common/altypes.hpp
+++ b/common/altypes.hpp
@@ -1,6 +1,7 @@
 #ifndef AL_TYPES_HPP
 #define AL_TYPES_HPP
 
+#include <cstdint>
 #include <cstdio>
 #include <cstddef>
 


### PR DESCRIPTION
Fixes:
```
/build/openal-soft-1.25.0/common/altypes.hpp:10:17: error: 'int8_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
   10 | using i8 = std::int8_t;
      |                 ^~~~~~
      |                 wint_t
…
```