### PR TITLE
Add support for visionOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1241,7 +1241,7 @@ if(ALSOFT_BACKEND_COREAUDIO)
         set(BACKENDS  "${BACKENDS} CoreAudio,")
 
         set(EXTRA_LIBS -Wl,-framework,CoreAudio ${EXTRA_LIBS})
-        if(CMAKE_SYSTEM_NAME MATCHES "^(iOS|tvOS)$")
+        if(CMAKE_SYSTEM_NAME MATCHES "^(iOS|tvOS|visionOS)$")
             find_library(COREFOUNDATION_FRAMEWORK NAMES CoreFoundation)
             if(COREFOUNDATION_FRAMEWORK)
                 set(EXTRA_LIBS -Wl,-framework,CoreFoundation ${EXTRA_LIBS})

--- a/alc/backends/coreaudio.cpp
+++ b/alc/backends/coreaudio.cpp
@@ -48,7 +48,7 @@
 #include <AudioUnit/AudioUnit.h>
 #include <AudioToolbox/AudioToolbox.h>
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 #define CAN_ENUMERATE 0
 #else
 #include <IOKit/audio/IOAudioTypes.h>


### PR DESCRIPTION
This PR adds support for visionOS. openal-info gives the following output on a Vision Pro 2024 device:

> Available playback devices:
>     CoreAudio Default
> Available capture devices:
>     CoreAudio Default
> Default playback device: CoreAudio Default
> Default capture device: CoreAudio Default
> ALC version: 1.1
> 
> ** Info for device "CoreAudio Default" **
> ALC version: 1.1
> ALC extensions:
>     ALC_ENUMERATE_ALL_EXT, ALC_ENUMERATION_EXT, ALC_EXT_CAPTURE, ALC_EXT_debug,
>     ALC_EXT_DEDICATED, ALC_EXT_direct_context, ALC_EXT_disconnect, ALC_EXT_EFX,
>     ALC_EXT_thread_local_context, ALC_SOFT_device_clock, ALC_SOFT_HRTF,
>     ALC_SOFT_loopback, ALC_SOFT_loopback_bformat, ALC_SOFT_output_limiter,
>     ALC_SOFT_output_mode, ALC_SOFT_pause_device, ALC_SOFT_reopen_device,
>     ALC_SOFT_system_events
> Available HRTF profiles:
>     Built-In HRTF
> Available events:
>     ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT for ALC_PLAYBACK_DEVICE_SOFT - SUPPORTED
>     ALC_EVENT_TYPE_DEFAULT_DEVICE_CHANGED_SOFT for ALC_CAPTURE_DEVICE_SOFT - SUPPORTED
>     ALC_EVENT_TYPE_DEVICE_ADDED_SOFT for ALC_PLAYBACK_DEVICE_SOFT - NOT SUPPORTED
>     ALC_EVENT_TYPE_DEVICE_ADDED_SOFT for ALC_CAPTURE_DEVICE_SOFT - NOT SUPPORTED
>     ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT for ALC_PLAYBACK_DEVICE_SOFT - NOT SUPPORTED
>     ALC_EVENT_TYPE_DEVICE_REMOVED_SOFT for ALC_CAPTURE_DEVICE_SOFT - NOT SUPPORTED
> Device output mode: Stereo (basic)
> Device sample rate: 48000hz
> Device HRTF profile: (disabled)
> Device number of mono sources: 255
> Device number of stereo sources: 1
> OpenAL vendor string: OpenAL Community
> OpenAL renderer string: OpenAL Soft
> OpenAL version string: 1.1 ALSOFT 1.25.0
> OpenAL extensions:
>     AL_EXT_ALAW, AL_EXT_BFORMAT, AL_EXT_debug, AL_EXT_direct_context,
>     AL_EXT_DOUBLE, AL_EXT_EXPONENT_DISTANCE, AL_EXT_FLOAT32, AL_EXT_IMA4,
>     AL_EXT_LINEAR_DISTANCE, AL_EXT_MCFORMATS, AL_EXT_MULAW,
>     AL_EXT_MULAW_BFORMAT, AL_EXT_MULAW_MCFORMATS, AL_EXT_OFFSET,
>     AL_EXT_source_distance_model, AL_EXT_SOURCE_RADIUS, AL_EXT_STATIC_BUFFER,
>     AL_EXT_STEREO_ANGLES, AL_LOKI_quadriphonic, AL_SOFT_bformat_ex,
>     AL_SOFT_bformat_hoa, AL_SOFT_block_alignment, AL_SOFT_buffer_length_query,
>     AL_SOFT_callback_buffer, AL_SOFTX_convolution_effect,
>     AL_SOFT_deferred_updates, AL_SOFT_direct_channels,
>     AL_SOFT_direct_channels_remix, AL_SOFT_effect_target, AL_SOFT_events,
>     AL_SOFT_gain_clamp_ex, AL_SOFTX_hold_on_disconnect, AL_SOFT_loop_points,
>     AL_SOFTX_map_buffer, AL_SOFT_MSADPCM, AL_SOFT_source_latency,
>     AL_SOFT_source_length, AL_SOFTX_source_panning, AL_SOFT_source_resampler,
>     AL_SOFT_source_spatialize, AL_SOFT_source_start_delay, AL_SOFT_UHJ,
>     AL_SOFT_UHJ_ex
> Available resamplers:
>     Nearest
>     Linear
>     Cubic Spline *
>     4-point Gaussian
>     11th order Sinc (fast)
>     11th order Sinc
>     23rd order Sinc (fast)
>     23rd order Sinc
>     47th order Sinc (fast)
>     47th order Sinc
> EFX version: 1.0
> Max auxiliary sends: 2
> OpenAL Error: Out of Memory (0xa005), @ 390
> Supported filters:
>     !!! none !!!
> OpenAL Error: Invalid Name (0xa001), @ 409
> Supported effects:
>     !!! none !!!
> OpenAL Error: Invalid Name (0xa001), @ 450

The 'OpenAL Error: Out of Memory' logging seems to be an existing bug shared with iOS. It's using an alternate allocator in almalloc that's getting flipped on because MAC_OS_X_VERSION_MIN_REQUIRED is queried and the result is outside the expected range on other platforms.

This PR was also tested with `altonegen` and proper output was produced. The same CoreAudio backend as macOS/iOS is used.