### PR TITLE
Changed the group of `param` in command `alcGetIntegerv` in `al.xml`

### DIFF
--- a/registry/xml/al.xml
+++ b/registry/xml/al.xml
@@ -3406,7 +3406,7 @@ typedef void (ALC_APIENTRY*<name>ALCEVENTPROCTYPESOFT</name>)(<type>ALCenum</typ
         <command export="alc" comment="Returns information about the device and the version of OpenAL.">
             <proto>void <name>alcGetIntegerv</name></proto>
             <param><ptype>ALCdevice</ptype> *<name>device</name></param>
-            <param group="ContextFloat"><ptype>ALCenum</ptype> <name>param</name></param>
+            <param group="ContextInteger"><ptype>ALCenum</ptype> <name>param</name></param>
             <param><ptype>ALCsizei</ptype> <name>size</name></param>
             <param len="size"><ptype>ALCint</ptype> *<name>values</name></param>
         </command>


### PR DESCRIPTION
## Description

The `al.xml` says that second parameter of the function `alcGetIntegerv` is `ALCenum` of group `ContextFloat`, even though `ContextFloat` does not appear anywhere else.

https://github.com/kcat/openal-soft/blob/7ee28ec968fe2d73c075316e6951051aeff7e34f/registry/xml/al.xml#L3406-L3412

According to the `GetIntegerv` in `alc.cpp`, it should be `ContextInteger` instead, as that function uses something like `ALC_FREQUENCY` and `ALC_REFRESH`, which are grouped as `ContextInteger` in the XML.

https://github.com/kcat/openal-soft/blob/7ee28ec968fe2d73c075316e6951051aeff7e34f/alc/alc.cpp#L2167-L2481

So I changed the group of `param` to `ContextInteger`.