### PR TITLE
Adding support for X714ChanMap to CoreAudio

### DIFF
--- a/alc/backends/coreaudio.cpp
+++ b/alc/backends/coreaudio.cpp
@@ -89,6 +89,15 @@ constexpr std::array<AudioChannelLabel, 8> X71ChanMap {
         kAudioChannelLabel_LeftSurround, kAudioChannelLabel_RightSurround,
         kAudioChannelLabel_LeftCenter, kAudioChannelLabel_RightCenter
 };
+constexpr std::array<AudioChannelLabel, 12> X714ChanMap {
+        kAudioChannelLabel_Left, kAudioChannelLabel_Right, kAudioChannelLabel_Center, kAudioChannelLabel_LFEScreen,
+    kAudioChannelLabel_LeftSurround, kAudioChannelLabel_RightSurround,
+    kAudioChannelLabel_LeftSideSurround,
+    kAudioChannelLabel_RightSideSurround,
+    kAudioChannelLabel_LeftTopFront,
+    kAudioChannelLabel_RightTopFront,
+    kAudioChannelLabel_LeftTopRear, kAudioChannelLabel_RightTopRear
+};
 
 struct FourCCPrinter {
     char mString[sizeof(UInt32) + 1]{};
@@ -531,7 +540,8 @@ bool CoreAudioPlayback::reset()
         bool is_51rear;
     };
 
-    static constexpr std::array<ChannelMap, 7> chanmaps{{
+    static constexpr std::array<ChannelMap, 8> chanmaps{{
+        { DevFmtX714, X714ChanMap, false },
         { DevFmtX71, X71ChanMap, false },
         { DevFmtX61, X61ChanMap, false },
         { DevFmtX51, X51ChanMap, false },


### PR DESCRIPTION
I'm working on adding support for Apple Spatial Audio - similar to the Spatial Sound support that was added for Windows. Adding 7.1.4 audio support in order to support that effort.