### PR TITLE
Fix double-processing of first sample in Multi2Mono channel converter

### DIFF
--- a/core/converter.cpp
+++ b/core/converter.cpp
@@ -161,7 +161,7 @@ void Multi2Mono(unsigned chanmask, usize const step, std::span<float> const dst,
         auto ssrc = srcspan.begin();
         std::advance(ssrc, c);
         dst.front() += LoadSample<T>(*ssrc);
-        std::ranges::for_each(dst, [&ssrc,step](float &sample)
+        std::ranges::for_each(dst | std::views::drop(1), [&ssrc,step](float &sample)
         {
             std::advance(ssrc, step);
             sample += LoadSample<T>(*ssrc);


### PR DESCRIPTION
The `Multi2Mono` function in `core/converter.cpp` processes the first destination sample twice, causing audio crackling/artifacts when capturing from a multi-channel device to mono.

The refactored code (introduced in 1.25.0) processes `dst.front()` before the loop, then iterates over the entire `dst` span with `std::ranges::for_each`, which includes `dst[0]` again. Since `Multi2Mono` accumulates (adds) samples, this results in the first sample of each block getting a double contribution from the wrong source offset.

### Before (buggy)
```cpp
dst.front() += LoadSample<T>(*ssrc);
std::ranges::for_each(dst, [&ssrc,step](float &sample)
{
    std::advance(ssrc, step);
    sample += LoadSample<T>(*ssrc);
});
```

### After (fixed)
```cpp
dst.front() += LoadSample<T>(*ssrc);
std::ranges::for_each(dst | std::views::drop(1), [&ssrc,step](float &sample)
{
    std::advance(ssrc, step);
    sample += LoadSample<T>(*ssrc);
});
```
**Reproduction:** 
1. Open a mono capture on a device that exposes stereo (e.g. GoXLR on WASAPI)
2. Record audio - crackling/distortion is audible
3. Compare with 1.24.3 where the same capture is clean

The issue affects any capture path where mChannelConv performs a multi-channel to mono downmix.