### PR TITLE
Allow disabling dynamic loading of optional libs on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,12 +662,17 @@ if(HAVE_LIBRT)
 endif()
 
 # Check for the dlopen API (for dynamically loading backend libs)
+set(HAVE_DYNLOAD 0)
 if(ALSOFT_DLOPEN)
     check_include_file(dlfcn.h HAVE_DLFCN_H)
     check_library_exists(dl dlopen "" HAVE_LIBDL)
     if(HAVE_LIBDL)
         list(APPEND EXTRA_LIBS dl)
         list(APPEND CMAKE_REQUIRED_LIBRARIES dl)
+    endif()
+
+    if(HAVE_LIBDL OR WIN32)
+      set(HAVE_DYNLOAD 1)
     endif()
 endif()
 

--- a/common/dynload.cpp
+++ b/common/dynload.cpp
@@ -3,6 +3,8 @@
 
 #include "dynload.h"
 
+#if HAVE_DYNLOAD
+
 #ifdef _WIN32
 #include <windows.h>
 
@@ -76,4 +78,6 @@ auto GetSymbol(void *const handle, gsl::czstring const name) -> al::expected<voi
         return al::unexpected(err);
     return sym;
 }
+#endif
+
 #endif

--- a/common/dynload.h
+++ b/common/dynload.h
@@ -3,14 +3,14 @@
 
 #include "config.h"
 
+#if HAVE_DYNLOAD
+
 #if defined(_WIN32) || defined(HAVE_DLFCN_H)
 
 #include <string>
 
 #include "expected.hpp"
 #include "gsl/gsl"
-
-#define HAVE_DYNLOAD 1
 
 #include "dlopennote.h"
 
@@ -20,9 +20,7 @@ void CloseLib(void *handle);
 [[nodiscard]]
 auto GetSymbol(void *handle, gsl::czstring name) -> al::expected<void*, std::string>;
 
-#else
-
-#define HAVE_DYNLOAD 0
+#endif
 
 #endif
 

--- a/config.h.in
+++ b/config.h.in
@@ -46,6 +46,9 @@
 /* Define to 1 if we have C++20 modules, else 0 */
 #cmakedefine01 HAVE_CXXMODULES
 
+/* Define to 1 to enable dynamic loading of optional libs, else 0 */
+#cmakedefine01 HAVE_DYNLOAD
+
 /* Define to 1 if we have DBus/RTKit, else 0 */
 #cmakedefine01 HAVE_RTKIT
 


### PR DESCRIPTION
Currently, setting `ALSOFT_DLOPEN` to `OFF` on Linux disables dynamic library loading and instead requires them to be linked directly. However, on Windows the dynamic loading is always enabled, which might not always be wanted.

Set `HAVE_DYNLIB` to 0 on Windows as well if `ALSOFT_DLOPEN` is disabled and do not compile the corresponding code.