### PR TITLE
Use find_program to find git executable for consistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1437,8 +1437,8 @@ set(BACKENDS  "${BACKENDS} Null")
 # Get the known version info to create version.h
 set(LIB_VERSION ${OpenAL_VERSION})
 set(LIB_VERSION_NUM ${OpenAL_VERSION_MAJOR},${OpenAL_VERSION_MINOR},${OpenAL_VERSION_PATCH},0)
-find_package(Git)
-if(ALSOFT_UPDATE_BUILD_VERSION AND GIT_FOUND AND EXISTS "${OpenAL_SOURCE_DIR}/.git")
+find_program(GIT_EXECUTABLE NAMES git)
+if(ALSOFT_UPDATE_BUILD_VERSION AND GIT_EXECUTABLE AND EXISTS "${OpenAL_SOURCE_DIR}/.git")
     set(GIT_DIR "${OpenAL_SOURCE_DIR}/.git")
 
     # Check if this is a submodule, if it is then find the .git directory


### PR DESCRIPTION
It's useful when find host program only when cross-compiling