### PR TITLE
fix: avoid [[clang::nonblocking]] on Win32 (Clang/MSVC)

### DIFF
--- a/common/opthelpers.h
+++ b/common/opthelpers.h
@@ -62,7 +62,7 @@
 #define LIFETIMEBOUND
 #endif
 
-#if HAS_ATTRIBUTE(clang::nonblocking)
+#if HAS_ATTRIBUTE(clang::nonblocking) && !defined(_WIN32)
 #define NONBLOCKING [[clang::nonblocking]]
 #else
 #define NONBLOCKING


### PR DESCRIPTION
## Description  
Building OpenAL-soft with Clang on Win32 fails due to the use of [[clang::nonblocking]] in the NONBLOCKING macro. The attribute causes template deduction errors in MSVC’s STL implementation, resulting in compilation failures.

## Refer CI

https://github.com/axmolengine/axmol/actions/runs/25740837222/job/75590445367?pr=3154