### PR TITLE
Add missing <fstream> include

### DIFF
--- a/common/filesystem.h
+++ b/common/filesystem.h
@@ -60,6 +60,7 @@
 
 #ifdef GHC_USE_STD_FS
     #include <filesystem>
+    #include <fstream>
     namespace fs {
         using namespace std::filesystem;
         using ifstream = std::ifstream;


### PR DESCRIPTION
GCC 17 shuffles around some internal transitive includes, so an explicit <fstream> is needed now.