### PR TITLE
Fix compatibility with fmt 12.2.0

### DIFF
--- a/alc/alc.cpp
+++ b/alc/alc.cpp
@@ -101,7 +101,7 @@
 #include "effects/base.h"
 #include "export_list.h"
 #include "flexarray.h"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "fmt/ranges.h"
 #include "gsl/gsl"
 #include "inprogext.h"

--- a/alc/backends/pipewire.cpp
+++ b/alc/backends/pipewire.cpp
@@ -52,7 +52,7 @@
 #include "core/device.h"
 #include "core/helpers.h"
 #include "dynload.h"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "fmt/ranges.h"
 #include "opthelpers.h"
 #include "pragmadefs.h"

--- a/common/pffft.cpp
+++ b/common/pffft.cpp
@@ -72,7 +72,7 @@
 
 #include "almalloc.h"
 #include "altypes.hpp"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "fmt/ranges.h"
 #include "gsl/gsl"
 #include "opthelpers.h"

--- a/core/hrtf_loader.cpp
+++ b/core/hrtf_loader.cpp
@@ -13,7 +13,7 @@
 
 #include "alformat.hpp"
 #include "alnumeric.h"
-#include "fmt/core.h"
+#include "fmt/format.h"
 #include "fmt/ranges.h"
 #include "gsl/gsl"
 #include "hrtf.h"


### PR DESCRIPTION
## Problem

fmtlib/fmt deprecated `<fmt/core.h>` in commit [0007426](https://github.com/fmtlib/fmt/commit/0007426c2d8d22df6e56d3b4d109415242e683e0). Starting from fmt 12.2.0, using `<fmt/core.h>` causes compilation errors because the deprecated include is now opt-in only.

## Fix

Replace all `#include <fmt/core.h>` with `#include <fmt/format.h>`, which is the standard header in fmt 12.2.0+.