### PR TITLE
Fix warning on implicit numeric conversions

### DIFF
--- a/core/voice.cpp
+++ b/core/voice.cpp
@@ -1226,7 +1226,7 @@ void Voice::prepare(DeviceBase *device)
         -> std::pair<std::unique_ptr<DecoderBase>, unsigned>
     {
         using decoder_t = T::decoder_t;
-        return {std::make_unique<decoder_t>(), decoder_t::sInputPadding};
+        return {std::make_unique<decoder_t>(), static_cast<unsigned>(decoder_t::sInputPadding)};
     };
     if(mFmtChannels == FmtSuperStereo)
     {


### PR DESCRIPTION
This PR fixes a C4267 warning on MSVC, without the intent of changing any behavior.

The warnings show up even when you set the project to /W0 in the latest MSVC (18.8.1), assuming "/std:c++23preview".